### PR TITLE
Bug/88 update wiki links

### DIFF
--- a/lookup.py
+++ b/lookup.py
@@ -13,7 +13,7 @@ class BotcWiki:
         map(lambda x: x.capitalize(), words)
         final = "_".join(words)
         final = urllib.parse.quote(final)
-        return f'https://bloodontheclocktower.com/wiki/{final}'
+        return f'https://wiki.bloodontheclocktower.com/{final}'
 
 class LookupRole:
     def matches_other(self, other):

--- a/lookup.py
+++ b/lookup.py
@@ -10,7 +10,7 @@ import urllib
 class BotcWiki:
     def create_wiki_url(name):
         words = name.split(' ')
-        map(lambda x: x.capitalize(), words)
+        words = map(lambda x: x.capitalize(), words)
         final = "_".join(words)
         final = urllib.parse.quote(final)
         return f'https://wiki.bloodontheclocktower.com/{final}'

--- a/test_lookups.py
+++ b/test_lookups.py
@@ -195,12 +195,12 @@ class TestLookups(unittest.TestCase):
         self.assertEqual('unofficial_image_2', found_main_role.roles_in_script_infos[2].script_info.image)
 
     def test_botc_wiki_link_correct(self):
-        role1 = 'Washerwoman'
+        role1 = 'washerwoman'
         role1_expected_url = 'Washerwoman'
         role1_actual_url = lookup.BotcWiki.create_wiki_url(role1)
         self.assertEqual(f'https://wiki.bloodontheclocktower.com/{role1_expected_url}', role1_actual_url)
 
-        role2 = 'Fortune Teller'
+        role2 = 'fortune teller'
         role2_expected_url = 'Fortune_Teller'
         role2_actual_url = lookup.BotcWiki.create_wiki_url(role2)
         self.assertEqual(f'https://wiki.bloodontheclocktower.com/{role2_expected_url}', role2_actual_url)

--- a/test_lookups.py
+++ b/test_lookups.py
@@ -195,9 +195,15 @@ class TestLookups(unittest.TestCase):
         self.assertEqual('unofficial_image_2', found_main_role.roles_in_script_infos[2].script_info.image)
 
     def test_botc_wiki_link_correct(self):
-        role = 'Washerwoman'
-        url = lookup.BotcWiki.create_wiki_url(role)
-        self.assertEqual(f'https://wiki.bloodontheclocktower.com/{role}', url)
+        role1 = 'Washerwoman'
+        role1_expected_url = 'Washerwoman'
+        role1_actual_url = lookup.BotcWiki.create_wiki_url(role1)
+        self.assertEqual(f'https://wiki.bloodontheclocktower.com/{role1_expected_url}', role1_actual_url)
+
+        role2 = 'Fortune Teller'
+        role2_expected_url = 'Fortune_Teller'
+        role2_actual_url = lookup.BotcWiki.create_wiki_url(role2)
+        self.assertEqual(f'https://wiki.bloodontheclocktower.com/{role2_expected_url}', role2_actual_url)
 
 
 class TestLookupImpl(unittest.IsolatedAsyncioTestCase):

--- a/test_lookups.py
+++ b/test_lookups.py
@@ -194,6 +194,11 @@ class TestLookups(unittest.TestCase):
         self.assertEqual('unofficial_author_2', found_main_role.roles_in_script_infos[2].script_info.author)
         self.assertEqual('unofficial_image_2', found_main_role.roles_in_script_infos[2].script_info.image)
 
+    def test_botc_wiki_link_correct(self):
+        role = 'Washerwoman'
+        url = lookup.BotcWiki.create_wiki_url(role)
+        self.assertEqual(f'https://wiki.bloodontheclocktower.com/{role}', url)
+
 
 class TestLookupImpl(unittest.IsolatedAsyncioTestCase):
 


### PR DESCRIPTION
I wasn't able to actually run this in Python for some reason - it didn't seem to want to connect to Discord. Did our TOKEN file change or something for the C# version?

In any case, tests looked good, url it spat out worked (unlike previous url which did not work any longer).

closes #88