### PR TITLE
Updating vote timer timings to be a little nicer to use. Jumping from…

### DIFF
--- a/test_votetimer.py
+++ b/test_votetimer.py
@@ -334,7 +334,7 @@ class TestVoteTimerAsync(unittest.IsolatedAsyncioTestCase):
         
         self.assertEqual(3, ts.add_count)
         self.assertEqual(town1, ts.add_town_town_info)
-        self.assertEqual(town1_end_time-datetime.timedelta(seconds=300), ts.add_town_end_time)
+        self.assertEqual(town1_end_time-datetime.timedelta(seconds=240), ts.add_town_end_time)
 
         self.assertEqual(4, tb.send_count)
         self.assertTrue('5 minutes, 50 seconds' in tb.last_message)

--- a/votetimer.py
+++ b/votetimer.py
@@ -89,7 +89,7 @@ class VoteTimerController(IVoteTimerController):
         next_time = end_time
         delta = (end_time - now).total_seconds()
         if delta >= 0:
-            advance_times = [300, 60, 15, 0]
+            advance_times = [240, 120, 60, 15, 0]
             for x in advance_times:
                 if delta > x:
                     next_time = end_time - datetime.timedelta(seconds=x)


### PR DESCRIPTION
… 5 minutes to 1 minute is kinda lousy, and the new numbers we're using with the C# version are nicer. Closes #90