### PR TITLE
Channels can be found if names or IDs change

### DIFF
--- a/Bot.Api/Database/ITownDatabase.cs
+++ b/Bot.Api/Database/ITownDatabase.cs
@@ -5,16 +5,16 @@ namespace Bot.Api.Database
 {
     public interface ITownDatabase
 	{
-		public Task<ITownRecord?> GetTownRecord(ulong guildId, ulong controlChannelId);
+		public Task<ITownRecord?> GetTownRecordAsync(ulong guildId, ulong controlChannelId);
 
 		// Get all Towns present on this guild
-		public Task<IEnumerable<ITownRecord>> GetTownRecords(ulong guildId);
+		public Task<IEnumerable<ITownRecord>> GetTownRecordsAsync(ulong guildId);
 
-		public Task<bool> AddTown(ITown town, IMember author);
+		public Task<bool> AddTownAsync(ITown town, IMember author);
 	}
 
 	public static class ITownLookupExtensions
     {
-		public static Task<ITownRecord?> GetTownRecord(this ITownDatabase @this, TownKey townKey) => @this.GetTownRecord(townKey.GuildId, townKey.ControlChannelId);
+		public static Task<ITownRecord?> GetTownRecordAsync(this ITownDatabase @this, TownKey townKey) => @this.GetTownRecordAsync(townKey.GuildId, townKey.ControlChannelId);
     }
 }

--- a/Bot.Api/Database/ITownDatabase.cs
+++ b/Bot.Api/Database/ITownDatabase.cs
@@ -11,6 +11,7 @@ namespace Bot.Api.Database
 		public Task<IEnumerable<ITownRecord>> GetTownRecordsAsync(ulong guildId);
 
 		public Task<bool> AddTownAsync(ITown town, IMember author);
+		public Task<bool> UpdateTownAsync(ITown town);
 	}
 
 	public static class ITownLookupExtensions

--- a/Bot.Api/IBotClient.cs
+++ b/Bot.Api/IBotClient.cs
@@ -3,52 +3,14 @@ using System.Threading.Tasks;
 
 namespace Bot.Api
 {
-    public enum BotChannelType
-    {
-        Text,
-        Voice,
-    }
-
     public interface IBotClient
     {
         Task ConnectAsync(IServiceProvider serviceProvider);
 
-        Task<GetChannelResult> GetChannelAsync(ulong id, string? name, BotChannelType type);
-        Task<GetChannelCategoryResult> GetChannelCategoryAsync(ulong id, string? name);
+        Task<IChannel?> GetChannelAsync(ulong id);
+        Task<IChannelCategory?> GetChannelCategoryAsync(ulong id);
         Task<IGuild?> GetGuildAsync(ulong guildId);
 
         event EventHandler<EventArgs> Connected;
-    }
-
-    public enum ChannelUpdateRequired
-    {
-        None,
-        Id,
-        Name,
-    }
-
-    public class GetChannelResult : GetChannelResultBase<IChannel>
-    {
-        public GetChannelResult(IChannel? channel, ChannelUpdateRequired updateRequired)
-            : base(channel, updateRequired)
-        { }
-    }
-    public class GetChannelCategoryResult : GetChannelResultBase<IChannelCategory>
-    {
-        public GetChannelCategoryResult(IChannelCategory? channel, ChannelUpdateRequired updateRequired)
-            : base(channel, updateRequired)
-        { }
-    }
-
-    public class GetChannelResultBase<T> where T : class
-    {
-        public ChannelUpdateRequired UpdateRequired { get; }
-        public T? Channel { get; }
-
-        public GetChannelResultBase(T? channel, ChannelUpdateRequired updateRequired)
-        {
-            UpdateRequired = updateRequired;
-            Channel = channel;
-        }
     }
 }

--- a/Bot.Api/IBotClient.cs
+++ b/Bot.Api/IBotClient.cs
@@ -7,8 +7,6 @@ namespace Bot.Api
     {
         Task ConnectAsync(IServiceProvider serviceProvider);
 
-        Task<IChannel?> GetChannelAsync(ulong id);
-        Task<IChannelCategory?> GetChannelCategoryAsync(ulong id);
         Task<IGuild?> GetGuildAsync(ulong guildId);
 
         event EventHandler<EventArgs> Connected;

--- a/Bot.Api/IBotClient.cs
+++ b/Bot.Api/IBotClient.cs
@@ -1,17 +1,54 @@
-﻿using Bot.Api.Database;
-using System;
+﻿using System;
 using System.Threading.Tasks;
 
 namespace Bot.Api
 {
+    public enum BotChannelType
+    {
+        Text,
+        Voice,
+    }
+
     public interface IBotClient
     {
         Task ConnectAsync(IServiceProvider serviceProvider);
 
-        Task<ITown?> ResolveTownAsync(ITownRecord rec);
-
-        Task<IGuild?> GetGuild(ulong guildId);
+        Task<GetChannelResult> GetChannelAsync(ulong id, string? name, BotChannelType type);
+        Task<GetChannelCategoryResult> GetChannelCategoryAsync(ulong id, string? name);
+        Task<IGuild?> GetGuildAsync(ulong guildId);
 
         event EventHandler<EventArgs> Connected;
+    }
+
+    public enum ChannelUpdateRequired
+    {
+        None,
+        Id,
+        Name,
+    }
+
+    public class GetChannelResult : GetChannelResultBase<IChannel>
+    {
+        public GetChannelResult(IChannel? channel, ChannelUpdateRequired updateRequired)
+            : base(channel, updateRequired)
+        { }
+    }
+    public class GetChannelCategoryResult : GetChannelResultBase<IChannelCategory>
+    {
+        public GetChannelCategoryResult(IChannelCategory? channel, ChannelUpdateRequired updateRequired)
+            : base(channel, updateRequired)
+        { }
+    }
+
+    public class GetChannelResultBase<T> where T : class
+    {
+        public ChannelUpdateRequired UpdateRequired { get; }
+        public T? Channel { get; }
+
+        public GetChannelResultBase(T? channel, ChannelUpdateRequired updateRequired)
+        {
+            UpdateRequired = updateRequired;
+            Channel = channel;
+        }
     }
 }

--- a/Bot.Api/IGuild.cs
+++ b/Bot.Api/IGuild.cs
@@ -1,13 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Bot.Api
 {
-	public interface IGuild
+    public interface IGuild
 	{
 		public ulong Id { get; }
 
@@ -15,10 +12,10 @@ namespace Bot.Api
 
 		public IReadOnlyDictionary<ulong, IMember> Members { get; }
 
-		public Task<IChannel> CreateVoiceChannelAsync(string name, IChannel? parent = null);
-		public Task<IChannel> CreateTextChannelAsync(string name, IChannel? parent = null);
-		public Task<IChannel> CreateCategoryAsync(string name);
+		public Task<IChannel?> CreateVoiceChannelAsync(string name, IChannelCategory? parent = null);
+		public Task<IChannel?> CreateTextChannelAsync(string name, IChannelCategory? parent = null);
+		public Task<IChannelCategory?> CreateCategoryAsync(string name);
 
-		public Task<IRole> CreateRoleAsync(string name, Color color);
+		public Task<IRole?> CreateRoleAsync(string name, Color color);
 	}
 }

--- a/Bot.Api/IGuild.cs
+++ b/Bot.Api/IGuild.cs
@@ -21,5 +21,8 @@ namespace Bot.Api
         IChannel? GetChannel(ulong id);
 
 		IChannelCategory? GetChannelCategory(ulong id);
+
+		IReadOnlyCollection<IChannel> Channels { get; }
+		IReadOnlyCollection<IChannelCategory> ChannelCategories { get; }
     }
 }

--- a/Bot.Api/IGuild.cs
+++ b/Bot.Api/IGuild.cs
@@ -6,16 +6,20 @@ namespace Bot.Api
 {
     public interface IGuild
 	{
-		public ulong Id { get; }
+		ulong Id { get; }
 
-		public IReadOnlyDictionary<ulong, IRole> Roles { get; }
+		IReadOnlyDictionary<ulong, IRole> Roles { get; }
 
-		public IReadOnlyDictionary<ulong, IMember> Members { get; }
+		IReadOnlyDictionary<ulong, IMember> Members { get; }
 
-		public Task<IChannel?> CreateVoiceChannelAsync(string name, IChannelCategory? parent = null);
-		public Task<IChannel?> CreateTextChannelAsync(string name, IChannelCategory? parent = null);
-		public Task<IChannelCategory?> CreateCategoryAsync(string name);
+		Task<IChannel?> CreateVoiceChannelAsync(string name, IChannelCategory? parent = null);
+		Task<IChannel?> CreateTextChannelAsync(string name, IChannelCategory? parent = null);
+		Task<IChannelCategory?> CreateCategoryAsync(string name);
 
-		public Task<IRole?> CreateRoleAsync(string name, Color color);
-	}
+		Task<IRole?> CreateRoleAsync(string name, Color color);
+
+        IChannel? GetChannel(ulong id);
+
+		IChannelCategory? GetChannelCategory(ulong id);
+    }
 }

--- a/Bot.Api/ITownResolver.cs
+++ b/Bot.Api/ITownResolver.cs
@@ -1,0 +1,10 @@
+﻿using Bot.Api.Database;
+using System.Threading.Tasks;
+
+namespace Bot.Api
+{
+    public interface ITownResolver
+    {
+        Task<ITown?> ResolveTownAsync(ITownRecord rec);
+    }
+}

--- a/Bot.Core/BotGameplay.cs
+++ b/Bot.Core/BotGameplay.cs
@@ -104,14 +104,14 @@ namespace Bot.Core
             foreach(var u in game.Storytellers)
             {
                 if (storytellerRole != null && !u.Roles.Contains(storytellerRole))
-                        await MemberHelper.GrantRoleLoggingErrorsAsync(u, storytellerRole, logger);
+                    await MemberHelper.GrantRoleLoggingErrorsAsync(u, storytellerRole, logger);
                 if (villagerRole != null && !u.Roles.Contains(villagerRole))
                     await MemberHelper.GrantRoleLoggingErrorsAsync(u, villagerRole, logger);
             }
 
             foreach (var u in game.Villagers)
             {
-                if (storytellerRole != null && !u.Roles.Contains(storytellerRole))
+                if (storytellerRole != null && u.Roles.Contains(storytellerRole))
                     await MemberHelper.RevokeRoleLoggingErrorsAsync(u, storytellerRole, logger);
                 if (villagerRole != null && !u.Roles.Contains(villagerRole))
                     await MemberHelper.GrantRoleLoggingErrorsAsync(u, villagerRole, logger);

--- a/Bot.Core/BotGameplay.cs
+++ b/Bot.Core/BotGameplay.cs
@@ -9,6 +9,7 @@ namespace Bot.Core
     public class BotGameplay : BotTownLookupHelper, IVoteHandler
     {
         private readonly IActiveGameService m_activeGameService;
+        private readonly IBotClient m_client;
         private readonly IShuffleService m_shuffle;
         private readonly ITownCleanup m_townCleanup;
 
@@ -16,6 +17,7 @@ namespace Bot.Core
             : base(services)
 		{
             services.Inject(out m_activeGameService);
+            services.Inject(out m_client);
             services.Inject(out m_shuffle);
             services.Inject(out m_townCleanup);
 
@@ -361,7 +363,7 @@ namespace Bot.Core
             }
             else
             {
-                var guild = await m_client.GetGuild(townKey.GuildId);
+                var guild = await m_client.GetGuildAsync(townKey.GuildId);
 
                 foreach (var (_, user) in guild!.Members)
                 {

--- a/Bot.Core/BotGameplay.cs
+++ b/Bot.Core/BotGameplay.cs
@@ -98,31 +98,23 @@ namespace Bot.Core
         {
             Serilog.Log.Debug("GrantAndRevokeRoles in game {@game}", game);
 
-            IRole storytellerRole = town.StorytellerRole!;
-            IRole villagerRole = town.VillagerRole!;
+            IRole? storytellerRole = town.StorytellerRole;
+            IRole? villagerRole = town.VillagerRole;
 
             foreach(var u in game.Storytellers)
             {
-                if(!u.Roles.Contains(town.StorytellerRole))
-                {
-                    await MemberHelper.GrantRoleLoggingErrorsAsync(u, storytellerRole, logger);
-                }
-                if (!u.Roles.Contains(town.VillagerRole))
-                {
+                if (storytellerRole != null && !u.Roles.Contains(storytellerRole))
+                        await MemberHelper.GrantRoleLoggingErrorsAsync(u, storytellerRole, logger);
+                if (villagerRole != null && !u.Roles.Contains(villagerRole))
                     await MemberHelper.GrantRoleLoggingErrorsAsync(u, villagerRole, logger);
-                }
             }
 
             foreach (var u in game.Villagers)
             {
-                if(u.Roles.Contains(town.StorytellerRole))
-                {
+                if (storytellerRole != null && !u.Roles.Contains(storytellerRole))
                     await MemberHelper.RevokeRoleLoggingErrorsAsync(u, storytellerRole, logger);
-                }
-                if(!u.Roles.Contains(town.VillagerRole))
-                {
+                if (villagerRole != null && !u.Roles.Contains(villagerRole))
                     await MemberHelper.GrantRoleLoggingErrorsAsync(u, villagerRole, logger);
-                }
             }
         }
 
@@ -289,19 +281,16 @@ namespace Bot.Core
         // Helper for moving all players to Town Square (used by Day and Vote commands)
         private async Task MoveActivePlayersToTownSquare(IGame game, ITown town, IProcessLogger logger)
         {
-            foreach (var member in m_shuffle.Shuffle(game.AllPlayers))
-            {
-                await MemberHelper.MoveToChannelLoggingErrorsAsync(member, town.TownSquare!, logger);
-            }
+            if (town.TownSquare != null)
+                foreach (var member in m_shuffle.Shuffle(game.AllPlayers))
+                    await MemberHelper.MoveToChannelLoggingErrorsAsync(member, town.TownSquare, logger);
         }
 
         public async Task<string> PhaseDayUnsafe(IGame game, IProcessLogger processLog)
 		{
             var town = await GetValidTownOrLogErrorAsync(game.TownKey, processLog);
             if (town == null)
-            {
                 return "Failed to find a valid town!";
-            }
             // Doesn't currently work :(
             //await ClearCottagePermissions(game, processLog);
             await MoveActivePlayersToTownSquare(game, town, processLog);
@@ -312,9 +301,7 @@ namespace Bot.Core
         {
             var town = await GetValidTownOrLogErrorAsync(game.TownKey, processLog);
             if (town == null)
-            {
                 return "Failed to find a valid town!";
-            }
 
             await MoveActivePlayersToTownSquare(game, town, processLog);
             return "Moved all players to Town Square for voting!";
@@ -341,8 +328,10 @@ namespace Bot.Core
         private static async Task EndGameForUser(IMember user, ITown town, IProcessLogger logger)
         {
             await MemberHelper.RemoveStorytellerTag(user, logger);
-            await user.RevokeRoleAsync(town!.StorytellerRole!);
-            await user.RevokeRoleAsync(town!.VillagerRole!);
+            if (town.StorytellerRole != null)
+                await user.RevokeRoleAsync(town.StorytellerRole);
+            if (town.VillagerRole != null)
+                await user.RevokeRoleAsync(town.VillagerRole);
         }
 
         public async Task<string> EndGameUnsafe(TownKey townKey, IProcessLogger logger)
@@ -356,19 +345,15 @@ namespace Bot.Core
                 m_activeGameService.EndGame(town);
 
                 foreach (var user in game.AllPlayers)
-                {
                     await EndGameForUser(user, town, logger);
-                }
                 return "Thank you for playing Blood on the Clocktower!";
             }
             else
             {
                 var guild = await m_client.GetGuildAsync(townKey.GuildId);
-
-                foreach (var (_, user) in guild!.Members)
-                {
-                    await EndGameForUser(user, town, logger);
-                }
+                if (guild != null)
+                    foreach (var (_, user) in guild.Members)
+                        await EndGameForUser(user, town, logger);
                 return "Cleanup of inactive game complete";
             }
 

--- a/Bot.Core/BotGameplayInteractionHandler.cs
+++ b/Bot.Core/BotGameplayInteractionHandler.cs
@@ -230,11 +230,11 @@ namespace Bot.Core
 
         public Task MoreButtonPressed(IBotInteractionContext context)
         {
-            return m_townCommandQueue.QueueCommandAsync("Expanding options...", context, async () =>
+            return m_townCommandQueue.QueueCommandAsync("Expanding options...", context, () =>
             {
                 Serilog.Log.Information(ButtonLogMsg, "More", context.Guild, context.Member);
                 var message = "Here are all the options again!";
-                return new QueuedCommandResult(message, true, new[] { m_nightButton, m_dayButton, m_voteButton, m_endGameButton }, new[] { m_voteTimerMenu  });
+                return Task.FromResult(new QueuedCommandResult(message, true, new[] { m_nightButton, m_dayButton, m_voteButton, m_endGameButton }, new[] { m_voteTimerMenu  }));
             });
         }
 

--- a/Bot.Core/BotSetup.cs
+++ b/Bot.Core/BotSetup.cs
@@ -20,7 +20,7 @@ namespace Bot.Core
 
         public Task AddTown(ITown town, IMember author)
         {
-            return m_townDb.AddTown(town, author);
+            return m_townDb.AddTownAsync(town, author);
         }
 
         private static TownDescription FallbackToDefaults(TownDescription desc)

--- a/Bot.Core/BotTownLookupHelper.cs
+++ b/Bot.Core/BotTownLookupHelper.cs
@@ -11,15 +11,15 @@ namespace Bot.Core
     /// </summary>
     public abstract class BotTownLookupHelper
     {
-        protected readonly IBotClient m_client;
         protected readonly ITownDatabase m_townLookup;
+        protected readonly ITownResolver m_townResolver;
 
         protected const string InvalidTownMessage = "Couldn't find a registered town for this server and channel. Consider re-creating the town with `/createTown` or `/addTown`.";
 
         public BotTownLookupHelper(IServiceProvider serviceProvider)
         {
-            serviceProvider.Inject(out m_client);
             serviceProvider.Inject(out m_townLookup);
+            serviceProvider.Inject(out m_townResolver);
         }
 
         protected Task<ITown?> GetValidTownOrLogErrorAsync(TownKey townKey, IProcessLogger processLogger)
@@ -47,12 +47,9 @@ namespace Bot.Core
                 return null;
             }
 
-            var town = await m_client.ResolveTownAsync(townRec);
+            var town = await m_townResolver.ResolveTownAsync(townRec);
             if (town == null)
-            {
                 processLogger.LogMessage(InvalidTownMessage);
-                return null;
-            }
 
             return town;
         }

--- a/Bot.Core/BotTownLookupHelper.cs
+++ b/Bot.Core/BotTownLookupHelper.cs
@@ -29,7 +29,7 @@ namespace Bot.Core
 
         protected async Task<ITown?> GetValidTownOrLogErrorAsync(ulong guildId, ulong controlChannelId, IProcessLogger processLogger)
         {
-            var townRecordList = await m_townLookup.GetTownRecords(guildId);
+            var townRecordList = await m_townLookup.GetTownRecordsAsync(guildId);
             var townRec = townRecordList.Where(x => x.ControlChannelId == controlChannelId).FirstOrDefault();
             
             if (townRec == null)

--- a/Bot.Core/BotVoteTimer.cs
+++ b/Bot.Core/BotVoteTimer.cs
@@ -91,8 +91,8 @@ namespace Bot.Core
             private readonly IDateTime DateTime;
 
             private readonly ICallbackScheduler<TownKey> m_callbackScheduler;
-            private readonly IBotClient m_client;
             private readonly ITownDatabase m_townLookup;
+            private readonly ITownResolver m_townResolver;
             private readonly IVoteHandler m_voteHandler;
 
             private readonly Dictionary<TownKey, DateTime> m_townKeyToVoteTime = new();
@@ -101,8 +101,8 @@ namespace Bot.Core
             {
                 serviceProvider.Inject(out DateTime);
 
-                serviceProvider.Inject(out m_client);
                 serviceProvider.Inject(out m_townLookup);
+                serviceProvider.Inject(out m_townResolver);
                 serviceProvider.Inject(out m_voteHandler);
 
                 var callbackFactory = serviceProvider.GetService<ICallbackSchedulerFactory>();
@@ -134,7 +134,7 @@ namespace Bot.Core
                     var townRecord = await m_townLookup.GetTownRecord(townKey);
                     if (townRecord != null)
                     {
-                        var town = await m_client.ResolveTownAsync(townRecord);
+                        var town = await m_townResolver.ResolveTownAsync(townRecord);
                         if (town != null && town.VillagerRole != null)
                         {
                             var message = $"{town.VillagerRole.Mention} - Vote countdown stopped!";
@@ -203,7 +203,7 @@ namespace Bot.Core
                 if (townRecord == null)
                     return "Could not find town";
 
-                var town = await m_client.ResolveTownAsync(townRecord);
+                var town = await m_townResolver.ResolveTownAsync(townRecord);
                 if (town == null)
                     return "Could not find town";
 
@@ -222,7 +222,7 @@ namespace Bot.Core
                 if (townRecord == null)
                     return "Could not find town";
 
-                var town = await m_client.ResolveTownAsync(townRecord);
+                var town = await m_townResolver.ResolveTownAsync(townRecord);
                 if (town == null)
                     return "Could not find town";
 

--- a/Bot.Core/BotVoteTimer.cs
+++ b/Bot.Core/BotVoteTimer.cs
@@ -131,7 +131,7 @@ namespace Bot.Core
 
                 if (hadTown)
                 {
-                    var townRecord = await m_townLookup.GetTownRecord(townKey);
+                    var townRecord = await m_townLookup.GetTownRecordAsync(townKey);
                     if (townRecord != null)
                     {
                         var town = await m_townResolver.ResolveTownAsync(townRecord);
@@ -199,7 +199,7 @@ namespace Bot.Core
 
             private async Task<string> SendTimeRemainingMessageAsync(TownKey townKey, DateTime endTime, DateTime now)
             {
-                var townRecord = await m_townLookup.GetTownRecord(townKey);
+                var townRecord = await m_townLookup.GetTownRecordAsync(townKey);
                 if (townRecord == null)
                     return "Could not find town";
 
@@ -218,7 +218,7 @@ namespace Bot.Core
 
             private async Task<string> SendTimeToVoteMessageAsync(TownKey townKey)
             {
-                var townRecord = await m_townLookup.GetTownRecord(townKey);
+                var townRecord = await m_townLookup.GetTownRecordAsync(townKey);
                 if (townRecord == null)
                     return "Could not find town";
 

--- a/Bot.Core/ServiceFactory.cs
+++ b/Bot.Core/ServiceFactory.cs
@@ -28,6 +28,7 @@ namespace Bot.Core
             ServiceProvider sp = new(parentServices);
             sp.AddService<ITownCommandQueue>(new TownCommandQueue(sp));
             sp.AddService<ITownCleanup>(new TownCleanup(sp));
+            sp.AddService<ITownResolver>(new TownResolver(sp));
             var gameplay = new BotGameplay(sp);
             sp.AddService<IVoteHandler>(gameplay);
             var voteTimer = new BotVoteTimer(sp);

--- a/Bot.Core/TownResolver.cs
+++ b/Bot.Core/TownResolver.cs
@@ -55,7 +55,7 @@ namespace Bot.Core
 
         private static bool AnyUpdatesRequired(params GetChannelResultBase[] results) => results.Any(r => r.UpdateRequired != ChannelUpdateRequired.None);
 
-        private static GetChannelResult GetChannel(IGuild guild, ulong channelId, string? channelName, bool isVoice)
+        private static GetChannelResult GetChannel(IGuild guild, ulong channelId, string? channelName, bool expectedIsVoice)
         {
             ChannelUpdateRequired update = ChannelUpdateRequired.None;
 
@@ -64,7 +64,9 @@ namespace Bot.Core
                 channel = guild.Channels.FirstOrDefault(c => c.Name == channelName);
 
             if (channel != null)
-                if (channel.Name != channelName)
+                if (channel.IsVoice != expectedIsVoice)
+                    channel = null;
+                else if (channel.Name != channelName)
                     update = ChannelUpdateRequired.Name;
                 else if (channel.Id != channelId)
                     update = ChannelUpdateRequired.Id;

--- a/Bot.Core/TownResolver.cs
+++ b/Bot.Core/TownResolver.cs
@@ -38,6 +38,10 @@ namespace Bot.Core
                     StorytellerRole = GetRoleForGuild(guild, rec.StorytellerRoleId),
                     VillagerRole = GetRoleForGuild(guild, rec.VillagerRoleId),
                 };
+
+                if (chatChannelResult.UpdateRequired != ChannelUpdateRequired.None)
+                    await m_townDb.UpdateTownAsync(town);
+
                 return town;
             }
             return null;
@@ -45,8 +49,13 @@ namespace Bot.Core
 
         private async Task<GetChannelResult> GetChannelAsync(ulong channelId, string? channelName, bool isVoice)
         {
+            ChannelUpdateRequired update = ChannelUpdateRequired.None;
+
             var channel = await m_client.GetChannelAsync(channelId);
-            return new GetChannelResult(channel, ChannelUpdateRequired.None);
+            if (channel != null && channel.Name != channelName)
+                update = ChannelUpdateRequired.Name;
+
+            return new GetChannelResult(channel, update);
         }
 
         private async Task<GetChannelCategoryResult> GetChannelCategoryAsync(ulong channelId, string? channelName)

--- a/Bot.Core/TownResolver.cs
+++ b/Bot.Core/TownResolver.cs
@@ -8,9 +8,12 @@ namespace Bot.Core
     public class TownResolver : ITownResolver
     {
         private readonly IBotClient m_client;
+        private readonly ITownDatabase m_townDb;
+
         public TownResolver(IServiceProvider serviceProvider)
         {
             serviceProvider.Inject(out m_client);
+            serviceProvider.Inject(out m_townDb);
         }
 
         public async Task<ITown?> ResolveTownAsync(ITownRecord rec)

--- a/Bot.Core/TownResolver.cs
+++ b/Bot.Core/TownResolver.cs
@@ -1,0 +1,50 @@
+﻿using Bot.Api;
+using Bot.Api.Database;
+using System;
+using System.Threading.Tasks;
+
+namespace Bot.Core
+{
+    public class TownResolver : ITownResolver
+    {
+        private readonly IBotClient m_client;
+        public TownResolver(IServiceProvider serviceProvider)
+        {
+            serviceProvider.Inject(out m_client);
+        }
+
+        public async Task<ITown?> ResolveTownAsync(ITownRecord rec)
+        {
+            var guild = await m_client.GetGuildAsync(rec.GuildId);
+            if (guild != null)
+            {
+                var controlChannelResult = await m_client.GetChannelAsync(rec.ControlChannelId, rec.ControlChannel, BotChannelType.Text);
+                var dayCategoryResult = await m_client.GetChannelCategoryAsync(rec.DayCategoryId, rec.DayCategory);
+                var nightCategoryResult = await m_client.GetChannelCategoryAsync(rec.NightCategoryId, rec.NightCategory);
+                var chatChannelResult = await m_client.GetChannelAsync(rec.ChatChannelId, rec.ChatChannel, BotChannelType.Text);
+                var townSquareResult = await m_client.GetChannelAsync(rec.TownSquareId, rec.TownSquare, BotChannelType.Voice);
+
+                var town = new Town(rec)
+                {
+                    Guild = guild,
+                    ControlChannel = controlChannelResult.Channel,
+                    DayCategory = dayCategoryResult.Channel,
+                    NightCategory = nightCategoryResult.Channel,
+                    ChatChannel = chatChannelResult.Channel,
+                    TownSquare = townSquareResult.Channel,
+                    StorytellerRole = GetRoleForGuild(guild, rec.StorytellerRoleId),
+                    VillagerRole = GetRoleForGuild(guild, rec.VillagerRoleId),
+                };
+                return town;
+            }
+            return null;
+        }
+
+        private static IRole? GetRoleForGuild(IGuild guild, ulong roleId)
+        {
+            if (guild.Roles.TryGetValue(roleId, out var role))
+                return role;
+            return null;
+        }
+    }
+}

--- a/Bot.Core/TownResolver.cs
+++ b/Bot.Core/TownResolver.cs
@@ -22,11 +22,11 @@ namespace Bot.Core
             var guild = await m_client.GetGuildAsync(rec.GuildId);
             if (guild != null)
             {
-                var controlChannelResult = GetChannel(guild, rec.ControlChannelId, rec.ControlChannel, false);
                 var dayCategoryResult = GetChannelCategory(guild, rec.DayCategoryId, rec.DayCategory);
                 var nightCategoryResult = GetChannelCategory(guild, rec.NightCategoryId, rec.NightCategory);
-                var chatChannelResult = GetChannel(guild, rec.ChatChannelId, rec.ChatChannel, false);
-                var townSquareResult = GetChannel(guild, rec.TownSquareId, rec.TownSquare, true);
+                var controlChannelResult = GetChannel(guild, dayCategoryResult.Channel, rec.ControlChannelId, rec.ControlChannel, false);
+                var chatChannelResult = GetChannel(guild, dayCategoryResult.Channel, rec.ChatChannelId, rec.ChatChannel, false);
+                var townSquareResult = GetChannel(guild, dayCategoryResult.Channel, rec.TownSquareId, rec.TownSquare, true);
 
                 var town = new Town(rec)
                 {
@@ -55,13 +55,13 @@ namespace Bot.Core
 
         private static bool AnyUpdatesRequired(params GetChannelResultBase[] results) => results.Any(r => r.UpdateRequired != ChannelUpdateRequired.None);
 
-        private static GetChannelResult GetChannel(IGuild guild, ulong channelId, string? channelName, bool expectedIsVoice)
+        private static GetChannelResult GetChannel(IGuild guild, IChannelCategory? parentCategory, ulong channelId, string? channelName, bool expectedIsVoice)
         {
             ChannelUpdateRequired update = ChannelUpdateRequired.None;
 
             var channel = guild.GetChannel(channelId);
-            if (channel == null)
-                channel = guild.Channels.FirstOrDefault(c => c.Name == channelName);
+            if (channel == null && parentCategory != null)
+                channel = parentCategory!.Channels.FirstOrDefault(c => c.Name == channelName);
 
             if (channel != null)
                 if (channel.IsVoice != expectedIsVoice)

--- a/Bot.Core/TownResolver.cs
+++ b/Bot.Core/TownResolver.cs
@@ -60,8 +60,14 @@ namespace Bot.Core
             ChannelUpdateRequired update = ChannelUpdateRequired.None;
 
             var channel = guild.GetChannel(channelId);
-            if (channel != null && channel.Name != channelName)
-                update = ChannelUpdateRequired.Name;
+            if (channel == null)
+                channel = guild.Channels.FirstOrDefault(c => c.Name == channelName);
+
+            if (channel != null)
+                if (channel.Name != channelName)
+                    update = ChannelUpdateRequired.Name;
+                else if (channel.Id != channelId)
+                    update = ChannelUpdateRequired.Id;
 
             return new GetChannelResult(channel, update);
         }
@@ -71,9 +77,14 @@ namespace Bot.Core
             ChannelUpdateRequired update = ChannelUpdateRequired.None;
 
             var channelCategory = guild.GetChannelCategory(channelId);
+            if (channelCategory == null)
+                channelCategory = guild.ChannelCategories.FirstOrDefault(c => c.Name == channelName);
 
-            if (channelCategory != null && channelCategory.Name != channelName)
-                update = ChannelUpdateRequired.Name;
+            if (channelCategory != null)
+                if (channelCategory.Name != channelName)
+                    update = ChannelUpdateRequired.Name;
+                else if (channelCategory.Id != channelId)
+                    update = ChannelUpdateRequired.Id;
 
             return new GetChannelCategoryResult(channelCategory, update);
         }

--- a/Bot.Core/TownResolver.cs
+++ b/Bot.Core/TownResolver.cs
@@ -22,11 +22,11 @@ namespace Bot.Core
             var guild = await m_client.GetGuildAsync(rec.GuildId);
             if (guild != null)
             {
-                var controlChannelResult = await GetChannelAsync(rec.ControlChannelId, rec.ControlChannel, false);
-                var dayCategoryResult = await GetChannelCategoryAsync(rec.DayCategoryId, rec.DayCategory);
-                var nightCategoryResult = await GetChannelCategoryAsync(rec.NightCategoryId, rec.NightCategory);
-                var chatChannelResult = await GetChannelAsync(rec.ChatChannelId, rec.ChatChannel, false);
-                var townSquareResult = await GetChannelAsync(rec.TownSquareId, rec.TownSquare, true);
+                var controlChannelResult = GetChannel(guild, rec.ControlChannelId, rec.ControlChannel, false);
+                var dayCategoryResult = GetChannelCategory(guild, rec.DayCategoryId, rec.DayCategory);
+                var nightCategoryResult = GetChannelCategory(guild, rec.NightCategoryId, rec.NightCategory);
+                var chatChannelResult = GetChannel(guild, rec.ChatChannelId, rec.ChatChannel, false);
+                var townSquareResult = GetChannel(guild, rec.TownSquareId, rec.TownSquare, true);
 
                 var town = new Town(rec)
                 {
@@ -53,24 +53,24 @@ namespace Bot.Core
             return null;
         }
 
-        private bool AnyUpdatesRequired(params GetChannelResultBase[] results) => results.Any(r => r.UpdateRequired != ChannelUpdateRequired.None);
+        private static bool AnyUpdatesRequired(params GetChannelResultBase[] results) => results.Any(r => r.UpdateRequired != ChannelUpdateRequired.None);
 
-        private async Task<GetChannelResult> GetChannelAsync(ulong channelId, string? channelName, bool isVoice)
+        private static GetChannelResult GetChannel(IGuild guild, ulong channelId, string? channelName, bool isVoice)
         {
             ChannelUpdateRequired update = ChannelUpdateRequired.None;
 
-            var channel = await m_client.GetChannelAsync(channelId);
+            var channel = guild.GetChannel(channelId);
             if (channel != null && channel.Name != channelName)
                 update = ChannelUpdateRequired.Name;
 
             return new GetChannelResult(channel, update);
         }
 
-        private async Task<GetChannelCategoryResult> GetChannelCategoryAsync(ulong channelId, string? channelName)
+        private static GetChannelCategoryResult GetChannelCategory(IGuild guild, ulong channelId, string? channelName)
         {
             ChannelUpdateRequired update = ChannelUpdateRequired.None;
 
-            var channelCategory = await m_client.GetChannelCategoryAsync(channelId);
+            var channelCategory = guild.GetChannelCategory(channelId);
 
             if (channelCategory != null && channelCategory.Name != channelName)
                 update = ChannelUpdateRequired.Name;

--- a/Bot.DSharp/DSharpClient.cs
+++ b/Bot.DSharp/DSharpClient.cs
@@ -59,8 +59,6 @@ namespace Bot.DSharp
             await readyTcs.Task;
         }
 
-        public Task<IChannel?> GetChannelAsync(ulong id) => m_discord.GetChannelAsync(id);
-        public Task<IChannelCategory?> GetChannelCategoryAsync(ulong id) => m_discord.GetChannelCategoryAsync(id);
         public Task<IGuild?> GetGuildAsync(ulong id) => m_discord.GetGuildAsync(id);
 
         private Task ComponentInteractionCreated(IDiscordClient sender, DSharpPlus.EventArgs.ComponentInteractionCreateEventArgs e)

--- a/Bot.DSharp/DSharpClient.cs
+++ b/Bot.DSharp/DSharpClient.cs
@@ -67,14 +67,20 @@ namespace Bot.DSharp
             var guild = await GetGuildAsync(rec.GuildId);
             if (guild != null)
             {
+                var controlChannelResult = await GetChannelAsync(rec.ControlChannelId);
+                var dayCategoryResult = await GetChannelCategoryAsync(rec.DayCategoryId);
+                var nightCategoryResult = await GetChannelCategoryAsync(rec.NightCategoryId);
+                var chatChannelResult = await GetChannelAsync(rec.ChatChannelId);
+                var townSquareResult = await GetChannelAsync(rec.TownSquareId);
+
                 var town = new Town(rec)
                 {
                     Guild = guild,
-                    ControlChannel = await GetChannelAsync(rec.ControlChannelId),
-                    DayCategory = await GetChannelCategoryAsync(rec.DayCategoryId),
-                    NightCategory = await GetChannelCategoryAsync(rec.NightCategoryId),
-                    ChatChannel = await GetChannelAsync(rec.ChatChannelId),
-                    TownSquare = await GetChannelAsync(rec.TownSquareId),
+                    ControlChannel = controlChannelResult.Channel,
+                    DayCategory = dayCategoryResult.Channel,
+                    NightCategory = nightCategoryResult.Channel,
+                    ChatChannel = chatChannelResult.Channel,
+                    TownSquare = townSquareResult.Channel,
                     StorytellerRole = GetRoleForGuild(guild, rec.StorytellerRoleId),
                     VillagerRole = GetRoleForGuild(guild, rec.VillagerRoleId),
                 };
@@ -90,9 +96,9 @@ namespace Bot.DSharp
             return m_componentService.CallAsync(new DSharpComponentContext(e.Interaction));
         }
 
-        private async Task<IChannel?> GetChannelAsync(ulong id) => await m_discord.GetChannelAsync(id);
+        private async Task<GetChannelResult> GetChannelAsync(ulong id) => await m_discord.GetChannelAsync(id);
 
-        private async Task<IChannelCategory?> GetChannelCategoryAsync(ulong id) => await m_discord.GetChannelCategoryAsync(id);
+        private async Task<GetChannelCategoryResult> GetChannelCategoryAsync(ulong id) => await m_discord.GetChannelCategoryAsync(id);
 
         private static IRole? GetRoleForGuild(IGuild guild, ulong roleId)
         {

--- a/Bot.DSharp/DSharpClient.cs
+++ b/Bot.DSharp/DSharpClient.cs
@@ -67,11 +67,11 @@ namespace Bot.DSharp
             var guild = await GetGuildAsync(rec.GuildId);
             if (guild != null)
             {
-                var controlChannelResult = await GetChannelAsync(rec.ControlChannelId);
-                var dayCategoryResult = await GetChannelCategoryAsync(rec.DayCategoryId);
-                var nightCategoryResult = await GetChannelCategoryAsync(rec.NightCategoryId);
-                var chatChannelResult = await GetChannelAsync(rec.ChatChannelId);
-                var townSquareResult = await GetChannelAsync(rec.TownSquareId);
+                var controlChannelResult = await GetChannelAsync(rec.ControlChannelId, rec.ControlChannel, ChannelType.Text);
+                var dayCategoryResult = await GetChannelCategoryAsync(rec.DayCategoryId, rec.DayCategory);
+                var nightCategoryResult = await GetChannelCategoryAsync(rec.NightCategoryId, rec.NightCategory);
+                var chatChannelResult = await GetChannelAsync(rec.ChatChannelId, rec.ChatChannel, ChannelType.Text);
+                var townSquareResult = await GetChannelAsync(rec.TownSquareId, rec.TownSquare, ChannelType.Voice);
 
                 var town = new Town(rec)
                 {
@@ -96,9 +96,9 @@ namespace Bot.DSharp
             return m_componentService.CallAsync(new DSharpComponentContext(e.Interaction));
         }
 
-        private async Task<GetChannelResult> GetChannelAsync(ulong id) => await m_discord.GetChannelAsync(id);
+        private async Task<GetChannelResult> GetChannelAsync(ulong id, string? name, ChannelType type) => await m_discord.GetChannelAsync(id, name, type);
 
-        private async Task<GetChannelCategoryResult> GetChannelCategoryAsync(ulong id) => await m_discord.GetChannelCategoryAsync(id);
+        private async Task<GetChannelCategoryResult> GetChannelCategoryAsync(ulong id, string? name) => await m_discord.GetChannelCategoryAsync(id, name);
 
         private static IRole? GetRoleForGuild(IGuild guild, ulong roleId)
         {

--- a/Bot.DSharp/DSharpClient.cs
+++ b/Bot.DSharp/DSharpClient.cs
@@ -59,8 +59,8 @@ namespace Bot.DSharp
             await readyTcs.Task;
         }
 
-        public Task<GetChannelResult> GetChannelAsync(ulong id, string? name, BotChannelType type) => m_discord.GetChannelAsync(id, name, type);
-        public Task<GetChannelCategoryResult> GetChannelCategoryAsync(ulong id, string? name) => m_discord.GetChannelCategoryAsync(id, name);
+        public Task<IChannel?> GetChannelAsync(ulong id) => m_discord.GetChannelAsync(id);
+        public Task<IChannelCategory?> GetChannelCategoryAsync(ulong id) => m_discord.GetChannelCategoryAsync(id);
         public Task<IGuild?> GetGuildAsync(ulong id) => m_discord.GetGuildAsync(id);
 
         private Task ComponentInteractionCreated(IDiscordClient sender, DSharpPlus.EventArgs.ComponentInteractionCreateEventArgs e)

--- a/Bot.DSharp/DSharpClient.cs
+++ b/Bot.DSharp/DSharpClient.cs
@@ -1,5 +1,4 @@
 ﻿using Bot.Api;
-using Bot.Api.Database;
 using DSharpPlus;
 using DSharpPlus.SlashCommands;
 using System;

--- a/Bot.DSharp/DSharpClient.cs
+++ b/Bot.DSharp/DSharpClient.cs
@@ -60,51 +60,13 @@ namespace Bot.DSharp
             await readyTcs.Task;
         }
 
+        public Task<GetChannelResult> GetChannelAsync(ulong id, string? name, BotChannelType type) => m_discord.GetChannelAsync(id, name, type);
+        public Task<GetChannelCategoryResult> GetChannelCategoryAsync(ulong id, string? name) => m_discord.GetChannelCategoryAsync(id, name);
         public Task<IGuild?> GetGuildAsync(ulong id) => m_discord.GetGuildAsync(id);
-
-        public async Task<ITown?> ResolveTownAsync(ITownRecord rec)
-        {
-            var guild = await GetGuildAsync(rec.GuildId);
-            if (guild != null)
-            {
-                var controlChannelResult = await GetChannelAsync(rec.ControlChannelId, rec.ControlChannel, ChannelType.Text);
-                var dayCategoryResult = await GetChannelCategoryAsync(rec.DayCategoryId, rec.DayCategory);
-                var nightCategoryResult = await GetChannelCategoryAsync(rec.NightCategoryId, rec.NightCategory);
-                var chatChannelResult = await GetChannelAsync(rec.ChatChannelId, rec.ChatChannel, ChannelType.Text);
-                var townSquareResult = await GetChannelAsync(rec.TownSquareId, rec.TownSquare, ChannelType.Voice);
-
-                var town = new Town(rec)
-                {
-                    Guild = guild,
-                    ControlChannel = controlChannelResult.Channel,
-                    DayCategory = dayCategoryResult.Channel,
-                    NightCategory = nightCategoryResult.Channel,
-                    ChatChannel = chatChannelResult.Channel,
-                    TownSquare = townSquareResult.Channel,
-                    StorytellerRole = GetRoleForGuild(guild, rec.StorytellerRoleId),
-                    VillagerRole = GetRoleForGuild(guild, rec.VillagerRoleId),
-                };
-                return town;
-            }
-            return null;
-        }
-
-        public async Task<IGuild?> GetGuild(ulong guildId) => await m_discord.GetGuildAsync(guildId);
 
         private Task ComponentInteractionCreated(IDiscordClient sender, DSharpPlus.EventArgs.ComponentInteractionCreateEventArgs e)
         {
             return m_componentService.CallAsync(new DSharpComponentContext(e.Interaction));
-        }
-
-        private async Task<GetChannelResult> GetChannelAsync(ulong id, string? name, ChannelType type) => await m_discord.GetChannelAsync(id, name, type);
-
-        private async Task<GetChannelCategoryResult> GetChannelCategoryAsync(ulong id, string? name) => await m_discord.GetChannelCategoryAsync(id, name);
-
-        private static IRole? GetRoleForGuild(IGuild guild, ulong roleId)
-        {
-            if (guild.Roles.TryGetValue(roleId, out var role))
-                return role;
-            return null;
         }
 
         public class InvalidDiscordTokenException : Exception { }

--- a/Bot.DSharp/DSharpGuild.cs
+++ b/Bot.DSharp/DSharpGuild.cs
@@ -33,7 +33,7 @@ namespace Bot.DSharp
             }
 		}
 
-        public async Task<IChannel> CreateVoiceChannelAsync(string name, IChannel? parent = null)
+        public async Task<IChannel?> CreateVoiceChannelAsync(string name, IChannelCategory? parent = null)
         {
             DiscordChannel? dc = null;
             if (parent is DSharpChannel dp)
@@ -41,10 +41,10 @@ namespace Bot.DSharp
             else
                 dc = await Wrapped.CreateChannelAsync(name, DSharpPlus.ChannelType.Voice);
 
-            return new DSharpChannel(dc);
+            return dc != null ? new DSharpChannel(dc) : null;
         }
 
-        public async Task<IChannel> CreateTextChannelAsync(string name, IChannel? parent = null)
+        public async Task<IChannel?> CreateTextChannelAsync(string name, IChannelCategory? parent = null)
         {
             DiscordChannel? dc = null;
             if (parent is DSharpChannel dp)
@@ -52,19 +52,19 @@ namespace Bot.DSharp
             else
                 dc = await Wrapped.CreateChannelAsync(name, DSharpPlus.ChannelType.Text);
 
-            return new DSharpChannel(dc);
+            return dc != null ? new DSharpChannel(dc) : null;
         }
 
-        public async Task<IChannel> CreateCategoryAsync(string name)
+        public async Task<IChannelCategory?> CreateCategoryAsync(string name)
         {
             var c = await Wrapped.CreateChannelCategoryAsync(name);
-            return new DSharpChannel(c);
+            return c != null ? new DSharpChannelCategory(c) : null;
         }
 
-        public async Task<IRole> CreateRoleAsync(string name, Color color)
+        public async Task<IRole?> CreateRoleAsync(string name, Color color)
         {
             var r = await Wrapped.CreateRoleAsync(name, null, new DiscordColor(color.R, color.G, color.B));
-            return new DSharpRole(r);
+            return r != null ? new DSharpRole(r) : null;
         }
     }
 }

--- a/Bot.DSharp/DSharpGuild.cs
+++ b/Bot.DSharp/DSharpGuild.cs
@@ -2,6 +2,7 @@
 using DSharpPlus.Entities;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Bot.DSharp
@@ -70,7 +71,7 @@ namespace Bot.DSharp
         public IChannel? GetChannel(ulong id)
         {
             var channel = Wrapped.GetChannel(id);
-            if (channel != null && (channel.Type == DSharpPlus.ChannelType.Text || channel.Type == DSharpPlus.ChannelType.Voice))
+            if (channel != null && IsStandardChannel(channel))
                 return new DSharpChannel(channel);
             return null;
         }
@@ -78,9 +79,23 @@ namespace Bot.DSharp
         public IChannelCategory? GetChannelCategory(ulong id)
         {
             var channel = Wrapped.GetChannel(id);
-            if (channel != null && (channel.Type == DSharpPlus.ChannelType.Category))
+            if (channel != null && IsChannelCategory(channel))
                 return new DSharpChannelCategory(channel);
             return null;
+        }
+
+        public IReadOnlyCollection<IChannel> Channels => Wrapped.Channels.Values.Where(IsStandardChannel).Select(c => new DSharpChannel(c)).ToArray();
+
+        public IReadOnlyCollection<IChannelCategory> ChannelCategories => Wrapped.Channels.Values.Where(IsChannelCategory).Select(c => new DSharpChannelCategory(c)).ToArray();
+
+        private static bool IsStandardChannel(DiscordChannel channel)
+        {
+            return channel.Type == DSharpPlus.ChannelType.Text || channel.Type == DSharpPlus.ChannelType.Voice;
+        }
+
+        private static bool IsChannelCategory(DiscordChannel channel)
+        {
+            return channel.Type == DSharpPlus.ChannelType.Category;
         }
     }
 }

--- a/Bot.DSharp/DSharpGuild.cs
+++ b/Bot.DSharp/DSharpGuild.cs
@@ -35,7 +35,7 @@ namespace Bot.DSharp
 
         public async Task<IChannel?> CreateVoiceChannelAsync(string name, IChannelCategory? parent = null)
         {
-            DiscordChannel? dc = null;
+            DiscordChannel? dc;
             if (parent is DSharpChannel dp)
                 dc = await Wrapped.CreateChannelAsync(name, DSharpPlus.ChannelType.Voice, dp.Wrapped);
             else
@@ -46,7 +46,7 @@ namespace Bot.DSharp
 
         public async Task<IChannel?> CreateTextChannelAsync(string name, IChannelCategory? parent = null)
         {
-            DiscordChannel? dc = null;
+            DiscordChannel? dc;
             if (parent is DSharpChannel dp)
                 dc = await Wrapped.CreateChannelAsync(name, DSharpPlus.ChannelType.Text, dp.Wrapped);
             else
@@ -65,6 +65,22 @@ namespace Bot.DSharp
         {
             var r = await Wrapped.CreateRoleAsync(name, null, new DiscordColor(color.R, color.G, color.B));
             return r != null ? new DSharpRole(r) : null;
+        }
+
+        public IChannel? GetChannel(ulong id)
+        {
+            var channel = Wrapped.GetChannel(id);
+            if (channel != null && (channel.Type == DSharpPlus.ChannelType.Text || channel.Type == DSharpPlus.ChannelType.Voice))
+                return new DSharpChannel(channel);
+            return null;
+        }
+
+        public IChannelCategory? GetChannelCategory(ulong id)
+        {
+            var channel = Wrapped.GetChannel(id);
+            if (channel != null && (channel.Type == DSharpPlus.ChannelType.Category))
+                return new DSharpChannelCategory(channel);
+            return null;
         }
     }
 }

--- a/Bot.DSharp/IDiscordClient.cs
+++ b/Bot.DSharp/IDiscordClient.cs
@@ -16,8 +16,6 @@ namespace Bot.DSharp
         event AsyncEventHandler<IDiscordClient, ReadyEventArgs> Ready;
         event AsyncEventHandler<IDiscordClient, ComponentInteractionCreateEventArgs> ComponentInteractionCreated;
 
-        Task<IChannel?> GetChannelAsync(ulong id);
-        Task<IChannelCategory?> GetChannelCategoryAsync(ulong id);
         Task<IGuild?> GetGuildAsync(ulong id);
         Task ConnectAsync();
     }
@@ -48,18 +46,6 @@ namespace Bot.DSharp
         }
 
         public SlashCommandsExtension UseSlashCommands(SlashCommandsConfiguration config) => Wrapped.UseSlashCommands(config);
-
-        public async Task<IChannel?> GetChannelAsync(ulong id)
-        {
-            var channel = await Wrapped.GetChannelAsync(id);
-            return channel != null ? new DSharpChannel(channel) : null;
-        }
-
-        public async Task<IChannelCategory?> GetChannelCategoryAsync(ulong id)
-        {
-            var channel = await Wrapped.GetChannelAsync(id);
-            return channel != null ? new DSharpChannelCategory(channel) : null;
-        }
 
         public async Task<IGuild?> GetGuildAsync(ulong id) => new DSharpGuild(await Wrapped.GetGuildAsync(id));
         public Task ConnectAsync() => Wrapped.ConnectAsync();

--- a/Bot.DSharp/IDiscordClient.cs
+++ b/Bot.DSharp/IDiscordClient.cs
@@ -9,12 +9,6 @@ using System.Threading.Tasks;
 
 namespace Bot.DSharp
 {
-    public enum ChannelType
-    {
-        Text,
-        Voice,
-    }
-
     public interface IDiscordClient
     {
         SlashCommandsExtension UseSlashCommands(SlashCommandsConfiguration config);
@@ -22,7 +16,7 @@ namespace Bot.DSharp
         event AsyncEventHandler<IDiscordClient, ReadyEventArgs> Ready;
         event AsyncEventHandler<IDiscordClient, ComponentInteractionCreateEventArgs> ComponentInteractionCreated;
 
-        Task<GetChannelResult> GetChannelAsync(ulong id, string? name, ChannelType type);
+        Task<GetChannelResult> GetChannelAsync(ulong id, string? name, BotChannelType type);
         Task<GetChannelCategoryResult> GetChannelCategoryAsync(ulong id, string? name);
         Task<IGuild?> GetGuildAsync(ulong id);
         Task ConnectAsync();
@@ -55,7 +49,7 @@ namespace Bot.DSharp
 
         public SlashCommandsExtension UseSlashCommands(SlashCommandsConfiguration config) => Wrapped.UseSlashCommands(config);
 
-        public async Task<GetChannelResult> GetChannelAsync(ulong id, string? name, ChannelType type)
+        public async Task<GetChannelResult> GetChannelAsync(ulong id, string? name, BotChannelType type)
         {
             var channel = await Wrapped.GetChannelAsync(id);
             return new GetChannelResult(channel != null ? new DSharpChannel(channel) : null, ChannelUpdateRequired.None);
@@ -128,38 +122,6 @@ namespace Bot.DSharp
                     tasks.Add(eh.Invoke(mClientWrapper, e));
                 return Task.WhenAll(tasks);
             }
-        }
-    }
-
-    public enum ChannelUpdateRequired
-    {
-        None,
-        Id,
-        Name,
-    }
-
-    public class GetChannelResult : GetChannelResultBase<IChannel>
-    {
-        public GetChannelResult(IChannel? channel, ChannelUpdateRequired updateRequired)
-            : base(channel, updateRequired)
-        {}
-    }
-    public class GetChannelCategoryResult : GetChannelResultBase<IChannelCategory>
-    {
-        public GetChannelCategoryResult(IChannelCategory? channel, ChannelUpdateRequired updateRequired)
-            : base(channel, updateRequired)
-        {}
-    }
-
-    public class GetChannelResultBase<T> where T : class
-    {
-        public ChannelUpdateRequired UpdateRequired { get; }
-        public T? Channel { get; }
-
-        public GetChannelResultBase(T? channel, ChannelUpdateRequired updateRequired)
-        {
-            UpdateRequired = updateRequired;
-            Channel = channel;
         }
     }
 }

--- a/Bot.DSharp/IDiscordClient.cs
+++ b/Bot.DSharp/IDiscordClient.cs
@@ -9,6 +9,12 @@ using System.Threading.Tasks;
 
 namespace Bot.DSharp
 {
+    public enum ChannelType
+    {
+        Text,
+        Voice,
+    }
+
     public interface IDiscordClient
     {
         SlashCommandsExtension UseSlashCommands(SlashCommandsConfiguration config);
@@ -16,8 +22,8 @@ namespace Bot.DSharp
         event AsyncEventHandler<IDiscordClient, ReadyEventArgs> Ready;
         event AsyncEventHandler<IDiscordClient, ComponentInteractionCreateEventArgs> ComponentInteractionCreated;
 
-        Task<GetChannelResult> GetChannelAsync(ulong id);
-        Task<GetChannelCategoryResult> GetChannelCategoryAsync(ulong id);
+        Task<GetChannelResult> GetChannelAsync(ulong id, string? name, ChannelType type);
+        Task<GetChannelCategoryResult> GetChannelCategoryAsync(ulong id, string? name);
         Task<IGuild?> GetGuildAsync(ulong id);
         Task ConnectAsync();
     }
@@ -49,13 +55,13 @@ namespace Bot.DSharp
 
         public SlashCommandsExtension UseSlashCommands(SlashCommandsConfiguration config) => Wrapped.UseSlashCommands(config);
 
-        public async Task<GetChannelResult> GetChannelAsync(ulong id)
+        public async Task<GetChannelResult> GetChannelAsync(ulong id, string? name, ChannelType type)
         {
             var channel = await Wrapped.GetChannelAsync(id);
             return new GetChannelResult(channel != null ? new DSharpChannel(channel) : null, ChannelUpdateRequired.None);
         }
 
-        public async Task<GetChannelCategoryResult> GetChannelCategoryAsync(ulong id)
+        public async Task<GetChannelCategoryResult> GetChannelCategoryAsync(ulong id, string? name)
         {
             var channel = await Wrapped.GetChannelAsync(id);
             return new GetChannelCategoryResult(channel != null ? new DSharpChannelCategory(channel) : null, ChannelUpdateRequired.None);

--- a/Bot.DSharp/IDiscordClient.cs
+++ b/Bot.DSharp/IDiscordClient.cs
@@ -16,8 +16,8 @@ namespace Bot.DSharp
         event AsyncEventHandler<IDiscordClient, ReadyEventArgs> Ready;
         event AsyncEventHandler<IDiscordClient, ComponentInteractionCreateEventArgs> ComponentInteractionCreated;
 
-        Task<GetChannelResult> GetChannelAsync(ulong id, string? name, BotChannelType type);
-        Task<GetChannelCategoryResult> GetChannelCategoryAsync(ulong id, string? name);
+        Task<IChannel?> GetChannelAsync(ulong id);
+        Task<IChannelCategory?> GetChannelCategoryAsync(ulong id);
         Task<IGuild?> GetGuildAsync(ulong id);
         Task ConnectAsync();
     }
@@ -49,16 +49,16 @@ namespace Bot.DSharp
 
         public SlashCommandsExtension UseSlashCommands(SlashCommandsConfiguration config) => Wrapped.UseSlashCommands(config);
 
-        public async Task<GetChannelResult> GetChannelAsync(ulong id, string? name, BotChannelType type)
+        public async Task<IChannel?> GetChannelAsync(ulong id)
         {
             var channel = await Wrapped.GetChannelAsync(id);
-            return new GetChannelResult(channel != null ? new DSharpChannel(channel) : null, ChannelUpdateRequired.None);
+            return channel != null ? new DSharpChannel(channel) : null;
         }
 
-        public async Task<GetChannelCategoryResult> GetChannelCategoryAsync(ulong id, string? name)
+        public async Task<IChannelCategory?> GetChannelCategoryAsync(ulong id)
         {
             var channel = await Wrapped.GetChannelAsync(id);
-            return new GetChannelCategoryResult(channel != null ? new DSharpChannelCategory(channel) : null, ChannelUpdateRequired.None);
+            return channel != null ? new DSharpChannelCategory(channel) : null;
         }
 
         public async Task<IGuild?> GetGuildAsync(ulong id) => new DSharpGuild(await Wrapped.GetGuildAsync(id));

--- a/Bot.Database/MongoTownRecord.cs
+++ b/Bot.Database/MongoTownRecord.cs
@@ -1,15 +1,16 @@
-﻿using Bot.Api;
-using Bot.Api.Database;
+﻿using Bot.Api.Database;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Bot.Database
 {
-	// Implementation of Bot.Api.ITown that serializes to MongoDb
-	public class MongoTownRecord : ITownRecord
+    // Implementation of Bot.Api.ITown that serializes to MongoDb
+    public class MongoTownRecord : ITownRecord
 	{
-		public ObjectId _id { get; set; }
+        [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>")]
+        public ObjectId _id { get; set; }
 		[BsonElement("guild")]
 		public ulong GuildId { get; set; }
 		[BsonElement("controlChannel")]

--- a/Bot.Database/MongoTownRecord.cs
+++ b/Bot.Database/MongoTownRecord.cs
@@ -6,11 +6,10 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Bot.Database
 {
-    // Implementation of Bot.Api.ITown that serializes to MongoDb
-    public class MongoTownRecord : ITownRecord
+	// Implementation of Bot.Api.ITown that serializes to MongoDb
+	[BsonIgnoreExtraElements]
+	public class MongoTownRecord : ITownRecord
 	{
-        [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>")]
-        public ObjectId _id { get; set; }
 		[BsonElement("guild")]
 		public ulong GuildId { get; set; }
 		[BsonElement("controlChannel")]

--- a/Bot.Database/TownDatabase.cs
+++ b/Bot.Database/TownDatabase.cs
@@ -61,11 +61,10 @@ namespace Bot.Database
 			if (town.Guild == null || town.ControlChannel == null)
 				return false;
 
-			var oldRec = await GetTownRecordAsync(town.Guild.Id, town.ControlChannel.Id) as MongoTownRecord;
-			if (oldRec == null)
-				return false;
+            if (await GetTownRecordAsync(town.Guild.Id, town.ControlChannel.Id) is not MongoTownRecord oldRec)
+                return false;
 
-			var newRec = RecordFromTownAndAuthorInfo(town, oldRec.Author, oldRec.AuthorName);
+            var newRec = RecordFromTownAndAuthorInfo(town, oldRec.Author, oldRec.AuthorName);
 
 			await m_collection.InsertOneAsync(newRec);
 			return true;

--- a/Bot.Database/TownDatabase.cs
+++ b/Bot.Database/TownDatabase.cs
@@ -51,7 +51,7 @@ namespace Bot.Database
 			var newRec = RecordFromTown(town, author);
 
 			// TODO: error check this record?
-			await UpdateRecordAsync(newRec, false);
+			await UpdateRecordAsync(newRec);
 			return true;
         }
 
@@ -65,13 +65,13 @@ namespace Bot.Database
 
             var newRec = RecordFromTownAndAuthorInfo(town, oldRec.Author, oldRec.AuthorName);
 
-			await UpdateRecordAsync(newRec, true);
+			await UpdateRecordAsync(newRec);
 			return true;
 		}
 
-		private Task UpdateRecordAsync(MongoTownRecord record, bool upsert)
+		private Task UpdateRecordAsync(MongoTownRecord record)
         {
-			return m_collection.ReplaceOneAsync(GetTownMatchFilter(record.GuildId, record.ControlChannelId), record, new ReplaceOptions() { IsUpsert = upsert });
+			return m_collection.ReplaceOneAsync(GetTownMatchFilter(record.GuildId, record.ControlChannelId), record, new ReplaceOptions() { IsUpsert = true });
         }
 
 		public async Task<ITownRecord?> GetTownRecordAsync(ulong guildId, ulong channelId)

--- a/Bot.Database/TownDatabase.cs
+++ b/Bot.Database/TownDatabase.cs
@@ -64,7 +64,6 @@ namespace Bot.Database
                 return false;
 
             var newRec = RecordFromTownAndAuthorInfo(town, oldRec.Author, oldRec.AuthorName);
-			newRec._id = oldRec._id;
 
 			await UpdateRecordAsync(newRec, true);
 			return true;

--- a/Bot.Database/TownDatabase.cs
+++ b/Bot.Database/TownDatabase.cs
@@ -42,10 +42,9 @@ namespace Bot.Database
 				Author = author.Id,
 				Timestamp = DateTime.Now,
 			};
-
 		}
 
-        public async Task<bool> AddTown(ITown town, IMember author)
+        public async Task<bool> AddTownAsync(ITown town, IMember author)
         {
 			var newRec = RecordFromTown(town, author);
 
@@ -55,7 +54,7 @@ namespace Bot.Database
 			return true;
         }
 
-        public async Task<ITownRecord?> GetTownRecord(ulong guildId, ulong channelId)
+        public async Task<ITownRecord?> GetTownRecordAsync(ulong guildId, ulong channelId)
 		{
 			// Build a filter for the specific document we want
 			var builder = Builders<MongoTownRecord>.Filter;
@@ -66,7 +65,7 @@ namespace Bot.Database
 			return document;
 		}
 
-		public async Task<IEnumerable<ITownRecord>> GetTownRecords(ulong guildId)
+		public async Task<IEnumerable<ITownRecord>> GetTownRecordsAsync(ulong guildId)
         {
 			// Build a filter for the specific document we want
 			var builder = Builders<MongoTownRecord>.Filter;

--- a/Test.Bot.Core/GameTestBase.cs
+++ b/Test.Bot.Core/GameTestBase.cs
@@ -31,6 +31,7 @@ namespace Test.Bot.Core
         protected readonly Mock<IDateTime> DateTimeMock = new();
         protected readonly Mock<IGameActivityDatabase> GameActivityDatabaseMock = new();
         protected readonly Mock<ITownCleanup> TownCleanupMock = new();
+        protected readonly Mock<ITownResolver> TownResolverMock = new();
         protected readonly Mock<ITown> TownMock = new();
         protected readonly Mock<ITownRecord> TownRecordMock = new();
         protected readonly Mock<IBotClient> ClientMock = new();
@@ -80,6 +81,7 @@ namespace Test.Bot.Core
             RegisterMock(BotSystemMock);
             RegisterMock(ClientMock);
             RegisterMock(TownLookupMock);
+            RegisterMock(TownResolverMock);
             RegisterMock(DateTimeMock);
             RegisterMock(GameActivityDatabaseMock);
             RegisterMock(TownCleanupMock);
@@ -97,8 +99,9 @@ namespace Test.Bot.Core
             TownLookupMock.Setup(tl => tl.GetTownRecords(It.Is<ulong>(a => a == MockGuildId))).ReturnsAsync(new[] { TownRecordMock.Object });
 
             // ResolveTown expects the TownRecord and returns the Town
-            ClientMock.Setup(c => c.ResolveTownAsync(It.Is<ITownRecord>(tr => tr == TownRecordMock.Object))).ReturnsAsync(TownMock.Object);
-            ClientMock.Setup(c => c.GetGuild(It.Is<ulong>(x => x == MockGuildId))).ReturnsAsync(GuildMock.Object);
+            TownResolverMock.Setup(c => c.ResolveTownAsync(It.Is<ITownRecord>(tr => tr == TownRecordMock.Object))).ReturnsAsync(TownMock.Object);
+
+            ClientMock.Setup(c => c.GetGuildAsync(It.Is<ulong>(x => x == MockGuildId))).ReturnsAsync(GuildMock.Object);
 
             // By default, the ActiveGameService won't find a game for this context
             IGame? defaultGame = null;

--- a/Test.Bot.Core/GameTestBase.cs
+++ b/Test.Bot.Core/GameTestBase.cs
@@ -95,8 +95,8 @@ namespace Test.Bot.Core
                 .Returns((IEnumerable<IMember> input) => input.Reverse());
 
             // TownLookup expects MockGuildId and MockChannelId and returns the TownRecord
-            TownLookupMock.Setup(tl => tl.GetTownRecord(It.Is<ulong>(gid => gid == MockGuildId), It.Is<ulong>(cid => cid == MockControlChannelId))).ReturnsAsync(TownRecordMock.Object);
-            TownLookupMock.Setup(tl => tl.GetTownRecords(It.Is<ulong>(a => a == MockGuildId))).ReturnsAsync(new[] { TownRecordMock.Object });
+            TownLookupMock.Setup(tl => tl.GetTownRecordAsync(It.Is<ulong>(gid => gid == MockGuildId), It.Is<ulong>(cid => cid == MockControlChannelId))).ReturnsAsync(TownRecordMock.Object);
+            TownLookupMock.Setup(tl => tl.GetTownRecordsAsync(It.Is<ulong>(a => a == MockGuildId))).ReturnsAsync(new[] { TownRecordMock.Object });
 
             // ResolveTown expects the TownRecord and returns the Town
             TownResolverMock.Setup(c => c.ResolveTownAsync(It.Is<ITownRecord>(tr => tr == TownRecordMock.Object))).ReturnsAsync(TownMock.Object);

--- a/Test.Bot.Core/TestGameplayMisc.cs
+++ b/Test.Bot.Core/TestGameplayMisc.cs
@@ -73,7 +73,7 @@ namespace Test.Bot.Core
 
             // Could add other exceptions here for other types of commands, if needed
             Villager1Mock.Setup(m => m.MoveToChannelAsync(It.IsAny<IChannel>())).ThrowsAsync(thrownException);
-            TownLookupMock.Setup(tl => tl.GetTownRecords(It.IsAny<ulong>())).Throws(thrownException);
+            TownLookupMock.Setup(tl => tl.GetTownRecordsAsync(It.IsAny<ulong>())).Throws(thrownException);
             var gs = CreateGameplayInteractionHandler();
             var t = gameCommandTestFunc(gs, InteractionContextMock.Object);
             t.Wait(5);

--- a/Test.Bot.Core/TestServices.cs
+++ b/Test.Bot.Core/TestServices.cs
@@ -44,6 +44,7 @@ namespace Test.Bot.Core
         [InlineData(typeof(IBotMessaging), typeof(BotMessaging))]
         [InlineData(typeof(ITownCommandQueue), typeof(TownCommandQueue))]		
         [InlineData(typeof(ITownCleanup), typeof(TownCleanup))]
+        [InlineData(typeof(ITownResolver), typeof(TownResolver))]
         public void CreateBotServices_CreatesAllRequiredServices(Type serviceInterfaceType, Type serviceImplType)
         {
             RegisterMock(new Mock<IBotSystem>());

--- a/Test.Bot.Core/TestSetup.cs
+++ b/Test.Bot.Core/TestSetup.cs
@@ -91,8 +91,8 @@ namespace Test.Bot.Core
         {
             Mock<IGuild> guild = new();
             guild.SetupGet(x => x.Id).Returns(MockGuildId);
-            guild.Setup(x => x.CreateTextChannelAsync(It.IsAny<string>(), It.IsAny<IChannel?>())); // TODO: make this actually do something?
-            guild.Setup(x => x.CreateVoiceChannelAsync(It.IsAny<string>(), It.IsAny<IChannel?>())); // TODO: make this actually do something?
+            guild.Setup(x => x.CreateTextChannelAsync(It.IsAny<string>(), It.IsAny<IChannelCategory?>())); // TODO: make this actually do something?
+            guild.Setup(x => x.CreateVoiceChannelAsync(It.IsAny<string>(), It.IsAny<IChannelCategory?>())); // TODO: make this actually do something?
             guild.Setup(x => x.CreateCategoryAsync(It.IsAny<string>())); // TODO: make this actually do something?
             guild.Setup(x => x.CreateRoleAsync(It.IsAny<string>(), It.IsAny<Color>())); // TODO: make this actually do something?
             return guild;
@@ -171,17 +171,17 @@ namespace Test.Bot.Core
         {
             GuildMock.Verify(x => x.CreateCategoryAsync(It.Is<string>(s => s == DayCatName)), Times.Once);
             // TODO: how to make sure the calls happen with the correct parent channel
-            GuildMock.Verify(x => x.CreateVoiceChannelAsync(It.Is<string>(s => s == TownSquareName), It.IsAny<IChannel?>()), Times.Once);
+            GuildMock.Verify(x => x.CreateVoiceChannelAsync(It.Is<string>(s => s == TownSquareName), It.IsAny<IChannelCategory?>()), Times.Once);
             foreach (var name in bs.DefaultExtraDayChannels)
-                GuildMock.Verify(x => x.CreateVoiceChannelAsync(It.Is<string>(s => s == name), It.IsAny<IChannel?>()), Times.Once);
-            GuildMock.Verify(x => x.CreateTextChannelAsync(It.Is<string>(s => s == ControlChannelName), It.IsAny<IChannel?>()), Times.Once);
+                GuildMock.Verify(x => x.CreateVoiceChannelAsync(It.Is<string>(s => s == name), It.IsAny<IChannelCategory?>()), Times.Once);
+            GuildMock.Verify(x => x.CreateTextChannelAsync(It.Is<string>(s => s == ControlChannelName), It.IsAny<IChannelCategory?>()), Times.Once);
         }
 
         private void VerifyOptionalChannels(IBotSetup _)
         {
-            GuildMock.Verify(x => x.CreateTextChannelAsync(It.Is<string>(s => s == ChatChannelName), It.IsAny<IChannel?>()), Times.Once);
+            GuildMock.Verify(x => x.CreateTextChannelAsync(It.Is<string>(s => s == ChatChannelName), It.IsAny<IChannelCategory?>()), Times.Once);
             GuildMock.Verify(x => x.CreateCategoryAsync(It.Is<string>(s => s == NightCatName)), Times.Once);
-            GuildMock.Verify(x => x.CreateVoiceChannelAsync(It.Is<string>(s => s == IBotSetup.DefaultCottageName), It.IsAny<IChannel?>()), Times.Exactly(20));
+            GuildMock.Verify(x => x.CreateVoiceChannelAsync(It.Is<string>(s => s == IBotSetup.DefaultCottageName), It.IsAny<IChannelCategory?>()), Times.Exactly(20));
         }
 
         [Fact]
@@ -206,7 +206,7 @@ namespace Test.Bot.Core
             VerifyRequiredRoles(bs);
             // Make sure night stuff DIDN'T happen
             GuildMock.Verify(x => x.CreateCategoryAsync(It.Is<string>(s => s == NightCatName)), Times.Never);
-            GuildMock.Verify(x => x.CreateVoiceChannelAsync(It.Is<string>(s => s == IBotSetup.DefaultCottageName), It.IsAny<IChannel?>()), Times.Never);
+            GuildMock.Verify(x => x.CreateVoiceChannelAsync(It.Is<string>(s => s == IBotSetup.DefaultCottageName), It.IsAny<IChannelCategory?>()), Times.Never);
         }
 
         [Fact]
@@ -227,18 +227,18 @@ namespace Test.Bot.Core
             GuildMock.Verify(x => x.CreateCategoryAsync(It.Is<string>(s => s == dayCatName)), Times.Once);
             // TODO: how to make sure the calls happen with the correct parent channel
             var tsName = IBotSetup.DefaultTownSquareChannelName;
-            GuildMock.Verify(x => x.CreateVoiceChannelAsync(It.Is<string>(s => s == tsName), It.IsAny<IChannel?>()), Times.Once);
+            GuildMock.Verify(x => x.CreateVoiceChannelAsync(It.Is<string>(s => s == tsName), It.IsAny<IChannelCategory?>()), Times.Once);
             foreach (var name in bs.DefaultExtraDayChannels)
-                GuildMock.Verify(x => x.CreateVoiceChannelAsync(It.Is<string>(s => s == name), It.IsAny<IChannel?>()), Times.Once);
+                GuildMock.Verify(x => x.CreateVoiceChannelAsync(It.Is<string>(s => s == name), It.IsAny<IChannelCategory?>()), Times.Once);
             var ctrlName = string.Format(IBotSetup.DefaultControlChannelFormat, TownDesc.TownName);
-            GuildMock.Verify(x => x.CreateTextChannelAsync(It.Is<string>(s => s == ctrlName), It.IsAny<IChannel?>()), Times.Once);
+            GuildMock.Verify(x => x.CreateTextChannelAsync(It.Is<string>(s => s == ctrlName), It.IsAny<IChannelCategory?>()), Times.Once);
 
             // Chat should not have been created
-            GuildMock.Verify(x => x.CreateTextChannelAsync(It.Is<string>(s => s == ChatChannelName), It.IsAny<IChannel?>()), Times.Never);
+            GuildMock.Verify(x => x.CreateTextChannelAsync(It.Is<string>(s => s == ChatChannelName), It.IsAny<IChannelCategory?>()), Times.Never);
 
             // Might as well confirm Night still worked
             GuildMock.Verify(x => x.CreateCategoryAsync(It.Is<string>(s => s == NightCatName)), Times.Once);
-            GuildMock.Verify(x => x.CreateVoiceChannelAsync(It.Is<string>(s => s == IBotSetup.DefaultCottageName), It.IsAny<IChannel?>()), Times.Exactly(20));
+            GuildMock.Verify(x => x.CreateVoiceChannelAsync(It.Is<string>(s => s == IBotSetup.DefaultCottageName), It.IsAny<IChannelCategory?>()), Times.Exactly(20));
 
             // Check for default role names
             var stName = string.Format(IBotSetup.DefaultStorytellerRoleFormat, TownDesc.TownName);

--- a/Test.Bot.Core/TestSetup.cs
+++ b/Test.Bot.Core/TestSetup.cs
@@ -38,7 +38,7 @@ namespace Test.Bot.Core
             TownDesc = MakeDesc(GuildMock.Object, AuthorMock.Object);
 
             TownDatabaseMock = new();
-            TownDatabaseMock.Setup(x => x.AddTown(It.IsAny<ITown>(), It.IsAny<IMember>()));
+            TownDatabaseMock.Setup(x => x.AddTownAsync(It.IsAny<ITown>(), It.IsAny<IMember>()));
             RegisterMock(TownDatabaseMock);
         }
 
@@ -124,7 +124,7 @@ namespace Test.Bot.Core
             IMember author = AuthorMock.Object;
 
             Mock<ITownDatabase> townDb = new();
-            townDb.Setup(x => x.AddTown(It.IsAny<ITown>(), It.IsAny<IMember>()));
+            townDb.Setup(x => x.AddTownAsync(It.IsAny<ITown>(), It.IsAny<IMember>()));
             RegisterMock(townDb);
 
             BotSetup bs = new(GetServiceProvider());
@@ -132,7 +132,7 @@ namespace Test.Bot.Core
             t.Wait(50);
             Assert.True(t.IsCompleted);
 
-            townDb.Verify(x => x.AddTown(It.Is<ITown>(y => y == town), It.Is<IMember>(z => z == author)));
+            townDb.Verify(x => x.AddTownAsync(It.Is<ITown>(y => y == town), It.Is<IMember>(z => z == author)));
         }
 
         private BotSetup CreateTownAssertCompleted()
@@ -149,7 +149,7 @@ namespace Test.Bot.Core
         {
             CreateTownAssertCompleted();
 
-            TownDatabaseMock.Verify(x => x.AddTown(
+            TownDatabaseMock.Verify(x => x.AddTownAsync(
                 It.Is<ITown>(y => y.DayCategory!.Id == (ulong)DayCatName.GetHashCode() &&
                                   y.NightCategory!.Id == (ulong)NightCatName.GetHashCode() &&
                                   y.ControlChannel!.Id == (ulong)ControlChannelName.GetHashCode() &&

--- a/Test.Bot.Core/TestVoteTimer.cs
+++ b/Test.Bot.Core/TestVoteTimer.cs
@@ -55,7 +55,7 @@ namespace Test.Bot.Core
         [Fact]
         public void NoTownFound_SendsErrorMessage()
         {
-            ClientMock.Setup(c => c.ResolveTownAsync(It.IsAny<ITownRecord>())).ReturnsAsync(() => (ITown?)null);
+            TownResolverMock.Setup(c => c.ResolveTownAsync(It.IsAny<ITownRecord>())).ReturnsAsync(() => (ITown?)null);
 
             RunVoteTimerVerifyCompleted();
 

--- a/Test.Bot.Core/TestVoteTimer.cs
+++ b/Test.Bot.Core/TestVoteTimer.cs
@@ -45,7 +45,7 @@ namespace Test.Bot.Core
         [Fact]
         public void NoTownRecordFound_SendsErrorMessage()
         {
-            TownLookupMock.Setup(tl => tl.GetTownRecords(It.IsAny<ulong>())).ReturnsAsync(() => Enumerable.Empty<ITownRecord>());
+            TownLookupMock.Setup(tl => tl.GetTownRecordsAsync(It.IsAny<ulong>())).ReturnsAsync(() => Enumerable.Empty<ITownRecord>());
 
             RunVoteTimerVerifyCompleted();
 

--- a/Test.Bot.DSharp/Test.Bot.DSharp.csproj
+++ b/Test.Bot.DSharp/Test.Bot.DSharp.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Bot.Core\Bot.Core.csproj" />
     <ProjectReference Include="..\Bot.DSharp\Bot.DSharp.csproj" />
     <ProjectReference Include="..\Test.Bot.Base\Test.Bot.Base.csproj" />
   </ItemGroup>

--- a/Test.Bot.DSharp/TestChannelRetrieval.cs
+++ b/Test.Bot.DSharp/TestChannelRetrieval.cs
@@ -1,0 +1,185 @@
+﻿using Bot.Api;
+using Bot.Api.Database;
+using Bot.Core;
+using Bot.DSharp;
+using DSharpPlus;
+using Moq;
+using Test.Bot.Base;
+using Xunit;
+
+namespace Test.Bot.DSharp
+{
+    public class TestChannelRetrieval : TestBase
+    {
+        private readonly Mock<IDiscordClient> m_mockDiscordClient = new(MockBehavior.Strict);
+
+        private readonly Mock<IChannel> m_mockControlChannel = new(MockBehavior.Strict);
+        private readonly Mock<IChannel> m_mockTownSquareChannel = new(MockBehavior.Strict);
+        private readonly Mock<IChannel> m_mockChatChannel = new(MockBehavior.Strict);
+        private readonly Mock<IChannelCategory> m_mockDayChannelCategory = new(MockBehavior.Strict);
+        private readonly Mock<IChannelCategory> m_mockNightChannelCategory = new(MockBehavior.Strict);
+        private readonly Mock<ITownRecord> m_mockTownRecord = new(MockBehavior.Strict);
+
+        private const string MismatchedName = "mismatched name";
+        private const string ControlName = "control chan";
+        private const string TownSquareName = "TS chan";
+        private const string ChatName = "chat chan";
+        private const string DayCategoryName = "day cat";
+        private const string NightCategoryName = "night cat";
+
+        private const ulong MismatchedId = 0;
+        private const ulong ControlId = 1;
+        private const ulong TownSquareId = 2;
+        private const ulong ChatId = 3;
+        private const ulong DayCategoryId = 4;
+        private const ulong NightCategoryId = 5;
+
+        public TestChannelRetrieval()
+        {
+            var env = RegisterMock(new Mock<IEnvironment>());
+            env.Setup(e => e.GetEnvironmentVariable(It.IsAny<string>())).Returns("env var");
+
+            SetupChannelMock(m_mockDiscordClient, m_mockControlChannel, ControlId, ControlName, BotChannelType.Text);
+            SetupChannelMock(m_mockDiscordClient, m_mockTownSquareChannel, TownSquareId, TownSquareName, BotChannelType.Voice);
+            SetupChannelMock(m_mockDiscordClient, m_mockChatChannel, ChatId, ChatName, BotChannelType.Text);
+            SetupChannelCategoryMock(m_mockDiscordClient, m_mockDayChannelCategory, DayCategoryId, DayCategoryName);
+            SetupChannelCategoryMock(m_mockDiscordClient, m_mockNightChannelCategory, NightCategoryId, NightCategoryName);
+
+            m_mockTownRecord.SetupGet(tr => tr.ControlChannel).Returns(ControlName);
+            m_mockTownRecord.SetupGet(tr => tr.ControlChannelId).Returns(ControlId);
+            m_mockTownRecord.SetupGet(tr => tr.TownSquare).Returns(TownSquareName);
+            m_mockTownRecord.SetupGet(tr => tr.TownSquareId).Returns(TownSquareId);
+            m_mockTownRecord.SetupGet(tr => tr.ChatChannel).Returns(ChatName);
+            m_mockTownRecord.SetupGet(tr => tr.ChatChannelId).Returns(ChatId);
+            m_mockTownRecord.SetupGet(tr => tr.DayCategory).Returns(DayCategoryName);
+            m_mockTownRecord.SetupGet(tr => tr.DayCategoryId).Returns(DayCategoryId);
+            m_mockTownRecord.SetupGet(tr => tr.NightCategory).Returns(NightCategoryName);
+            m_mockTownRecord.SetupGet(tr => tr.NightCategoryId).Returns(NightCategoryId);
+
+            static void SetupChannelMock(Mock<IDiscordClient> clientMock, Mock<IChannel> channelMock, ulong channelId, string channelName, BotChannelType channelType)
+            {
+                channelMock.SetupGet(c => c.Id).Returns(channelId);
+                channelMock.SetupGet(c => c.Name).Returns(channelName);
+                clientMock.Setup(c => c.GetChannelAsync(It.Is<ulong>(id => id == channelId), It.Is<string>(s => s == channelName), It.Is<BotChannelType>(ct => ct == channelType))).ReturnsAsync(new GetChannelResult(channelMock.Object, ChannelUpdateRequired.None));
+                clientMock.Setup(c => c.GetChannelAsync(It.Is<ulong>(id => id == MismatchedId), It.Is<string>(s => s == channelName), It.Is<BotChannelType>(ct => ct == channelType))).ReturnsAsync(new GetChannelResult(channelMock.Object, ChannelUpdateRequired.Id));
+                clientMock.Setup(c => c.GetChannelAsync(It.Is<ulong>(id => id == channelId), It.Is<string>(s => s == MismatchedName), It.Is<BotChannelType>(ct => ct == channelType))).ReturnsAsync(new GetChannelResult(channelMock.Object, ChannelUpdateRequired.Name));
+
+                var otherType = channelType == BotChannelType.Text ? BotChannelType.Voice : BotChannelType.Text;
+                clientMock.Setup(c => c.GetChannelAsync(It.Is<ulong>(id => id == channelId), It.Is<string>(s => s == channelName), It.Is<BotChannelType>(ct => ct == otherType))).ReturnsAsync(new GetChannelResult(null, ChannelUpdateRequired.None));
+            }
+
+            static void SetupChannelCategoryMock(Mock<IDiscordClient> clientMock, Mock<IChannelCategory> channelMock, ulong channelId, string channelName)
+            {
+                channelMock.SetupGet(c => c.Id).Returns(channelId);
+                channelMock.SetupGet(c => c.Name).Returns(channelName);
+                clientMock.Setup(c => c.GetChannelCategoryAsync(It.Is<ulong>(id => id == channelId), It.Is<string>(s => s == channelName))).ReturnsAsync(new GetChannelCategoryResult(channelMock.Object, ChannelUpdateRequired.None));
+                clientMock.Setup(c => c.GetChannelCategoryAsync(It.Is<ulong>(id => id == MismatchedId), It.Is<string>(s => s == channelName))).ReturnsAsync(new GetChannelCategoryResult(channelMock.Object, ChannelUpdateRequired.Id));
+                clientMock.Setup(c => c.GetChannelCategoryAsync(It.Is<ulong>(id => id == channelId), It.Is<string>(s => s == MismatchedName))).ReturnsAsync(new GetChannelCategoryResult(channelMock.Object, ChannelUpdateRequired.Name));
+            }
+
+            var mockFactory = RegisterMock(new Mock<IDiscordClientFactory>());
+            mockFactory.Setup(f => f.CreateClient(It.IsAny<DiscordConfiguration>())).Returns(m_mockDiscordClient.Object);
+        }
+
+        [Fact]
+        public void ControlChannelTypeMismatch_NullReturnChannel() => TestChannelTypeMismatch(m_mockControlChannel.Object, BotChannelType.Text);
+
+        [Fact]
+        public void ChatChannelTypeMismatch_NullReturnChannel() => TestChannelTypeMismatch(m_mockChatChannel.Object, BotChannelType.Text);
+
+        [Fact]
+        public void TownSquareChannelTypeMismatch_NullReturnChannel() => TestChannelTypeMismatch(m_mockTownSquareChannel.Object, BotChannelType.Voice);
+
+        private void TestChannelTypeMismatch(IChannel channel, BotChannelType channelType)
+        {
+            var client = new DSharpClient(GetServiceProvider());
+            var testType = channelType == BotChannelType.Text ? BotChannelType.Voice : BotChannelType.Text;
+            var channelTask = client.GetChannelAsync(channel.Id, channel.Name, testType);
+            channelTask.Wait(50);
+            Assert.True(channelTask.IsCompleted);
+            Assert.Null(channelTask.Result.Channel);
+        }
+
+        [Fact]
+        public void ControlChannelNameMismatch_RequestsUpdate() => TestChannelNameMismatch(m_mockControlChannel.Object, BotChannelType.Text);
+
+        [Fact]
+        public void ChatChannelNameMismatch_RequestsUpdate() => TestChannelNameMismatch(m_mockChatChannel.Object, BotChannelType.Text);
+
+        [Fact]
+        public void TownSquareChannelNameMismatch_RequestsUpdate() => TestChannelNameMismatch(m_mockTownSquareChannel.Object, BotChannelType.Voice);
+
+        private void TestChannelNameMismatch(IChannel channel, BotChannelType channelType)
+        {
+            var client = new DSharpClient(GetServiceProvider());
+            var channelTask = client.GetChannelAsync(channel.Id, MismatchedName, channelType);
+            channelTask.Wait(50);
+            Assert.True(channelTask.IsCompleted);
+            Assert.Equal(channel, channelTask.Result.Channel);
+            Assert.Equal(ChannelUpdateRequired.Name, channelTask.Result.UpdateRequired);
+        }
+
+        [Fact]
+        public void DayCatNameMismatch_RequestsUpdate() => TestChannelCategoryNameMismatch(m_mockDayChannelCategory.Object);
+
+        [Fact]
+        public void NightCatNameMismatch_RequestsUpdate() => TestChannelCategoryNameMismatch(m_mockNightChannelCategory.Object);
+
+        private void TestChannelCategoryNameMismatch(IChannelCategory channelCategory)
+        {
+            var client = new DSharpClient(GetServiceProvider());
+            var channelCatTask = client.GetChannelCategoryAsync(channelCategory.Id, MismatchedName);
+            channelCatTask.Wait(50);
+            Assert.True(channelCatTask.IsCompleted);
+            Assert.Equal(channelCategory, channelCatTask.Result.Channel);
+            Assert.Equal(ChannelUpdateRequired.Name, channelCatTask.Result.UpdateRequired);
+        }
+
+        [Fact]
+        public void ControlChannelIdMismatch_RequestsUpdate() => TestChannelIdMismatch(m_mockControlChannel.Object, BotChannelType.Text);
+
+        [Fact]
+        public void ChatChannelIdMismatch_RequestsUpdate() => TestChannelIdMismatch(m_mockChatChannel.Object, BotChannelType.Text);
+
+        [Fact]
+        public void TownSquareChannelIdMismatch_RequestsUpdate() => TestChannelIdMismatch(m_mockTownSquareChannel.Object, BotChannelType.Voice);
+
+        private void TestChannelIdMismatch(IChannel channel, BotChannelType channelType)
+        {
+            var client = new DSharpClient(GetServiceProvider());
+            var channelTask = client.GetChannelAsync(MismatchedId, channel.Name, channelType);
+            channelTask.Wait(50);
+            Assert.True(channelTask.IsCompleted);
+            Assert.Equal(channel, channelTask.Result.Channel);
+            Assert.Equal(ChannelUpdateRequired.Id, channelTask.Result.UpdateRequired);
+        }
+
+        [Fact]
+        public void DayCatIdMismatch_RequestsUpdate() => TestChannelCategoryIdMismatch(m_mockDayChannelCategory.Object);
+
+        [Fact]
+        public void NightCatIdMismatch_RequestsUpdate() => TestChannelCategoryIdMismatch(m_mockNightChannelCategory.Object);
+
+        private void TestChannelCategoryIdMismatch(IChannelCategory channelCategory)
+        {
+            var client = new DSharpClient(GetServiceProvider());
+            var channelCatTask = client.GetChannelCategoryAsync(MismatchedId, channelCategory.Name);
+            channelCatTask.Wait(50);
+            Assert.True(channelCatTask.IsCompleted);
+            Assert.Equal(channelCategory, channelCatTask.Result.Channel);
+            Assert.Equal(ChannelUpdateRequired.Id, channelCatTask.Result.UpdateRequired);
+        }
+
+        /*
+        [Fact]
+        public void TownResolveChatNameOff_RequestsUpdate()
+        {
+            var tr = new TownResolver(GetServiceProvider());
+            var resolveTask = tr.ResolveTownAsync(m_mockTownRecord.Object);
+            resolveTask.Wait(50);
+            Assert.True(resolveTask.IsCompleted);
+            
+        }
+        */
+    }
+}

--- a/Test.Bot.DSharp/TestChannelRetrieval.cs
+++ b/Test.Bot.DSharp/TestChannelRetrieval.cs
@@ -92,6 +92,10 @@ namespace Test.Bot.DSharp
             };
             m_mockGuild.SetupGet(g => g.Id).Returns(GuildId);
             m_mockGuild.SetupGet(g => g.Roles).Returns(roleDict);
+            IChannel[] channels = new[] { m_mockChatChannel.Object, m_mockControlChannel.Object, m_mockTownSquareChannel.Object };
+            IChannelCategory[] channelCategories = new[] { m_mockDayChannelCategory.Object, m_mockNightChannelCategory.Object };
+            m_mockGuild.SetupGet(g => g.Channels).Returns(channels);
+            m_mockGuild.SetupGet(g => g.ChannelCategories).Returns(channelCategories);
 
             m_mockTownDb.Setup(db => db.UpdateTownAsync(It.IsAny<ITown>())).ReturnsAsync(true);
         }
@@ -113,7 +117,6 @@ namespace Test.Bot.DSharp
         [Fact]
         public void TownResolve_NightCategoryNameOff_RequestsUpdate() => TestResolve_ChannelCategoryNameOff(m_mockNightChannelCategory);
 
-
         private void TestResolve_ChannelNameOff(Mock<IChannel> channel)
         {
             channel.SetupGet(c => c.Name).Returns(MismatchedName);
@@ -127,9 +130,26 @@ namespace Test.Bot.DSharp
         }
 
         [Fact]
-        public void TownResolveTownSquareNameOff_RequestsUpdate()
+        public void TownResolve_ChatIdOff_RequestsUpdate() => TestResolve_ChannelIdOff(m_mockChatChannel);
+        [Fact]
+        public void TownResolve_TownSquareIdOff_RequestsUpdate() => TestResolve_ChannelIdOff(m_mockTownSquareChannel);
+        [Fact]
+        public void TownResolve_ControlIdOff_RequestsUpdate() => TestResolve_ChannelIdOff(m_mockControlChannel);
+        [Fact]
+        public void TownResolve_DayCategoryIdOff_RequestsUpdate() => TestResolve_ChannelCategoryIdOff(m_mockDayChannelCategory);
+        [Fact]
+        public void TownResolve_NightCategoryIdOff_RequestsUpdate() => TestResolve_ChannelCategoryIdOff(m_mockNightChannelCategory);
+
+
+        private void TestResolve_ChannelIdOff(Mock<IChannel> channel)
         {
-            m_mockTownSquareChannel.SetupGet(c => c.Name).Returns(MismatchedName);
+            channel.SetupGet(c => c.Id).Returns(MismatchedId);
+            TestResolve_VerifyTownUpdated();
+        }
+
+        private void TestResolve_ChannelCategoryIdOff(Mock<IChannelCategory> channelCategory)
+        {
+            channelCategory.SetupGet(c => c.Id).Returns(MismatchedId);
             TestResolve_VerifyTownUpdated();
         }
 

--- a/Test.Bot.DSharp/TestChannelRetrieval.cs
+++ b/Test.Bot.DSharp/TestChannelRetrieval.cs
@@ -18,7 +18,8 @@ namespace Test.Bot.DSharp
         private readonly Mock<IChannel> m_mockChatChannel = new(MockBehavior.Strict);
         private readonly Mock<IChannelCategory> m_mockDayChannelCategory = new(MockBehavior.Strict);
         private readonly Mock<IChannelCategory> m_mockNightChannelCategory = new(MockBehavior.Strict);
-        private readonly Mock<ITownRecord> m_mockTownRecord = new(MockBehavior.Strict);
+        private readonly Mock<ITownRecord> m_mockTownRecord = new(MockBehavior.Loose);
+        private readonly Mock<ITownDatabase> m_mockTownDb = new(MockBehavior.Strict);
 
         private const string MismatchedName = "mismatched name";
         private const string ControlName = "control chan";
@@ -39,9 +40,9 @@ namespace Test.Bot.DSharp
             var env = RegisterMock(new Mock<IEnvironment>());
             env.Setup(e => e.GetEnvironmentVariable(It.IsAny<string>())).Returns("env var");
 
-            SetupChannelMock(m_mockDiscordClient, m_mockControlChannel, ControlId, ControlName, BotChannelType.Text);
-            SetupChannelMock(m_mockDiscordClient, m_mockTownSquareChannel, TownSquareId, TownSquareName, BotChannelType.Voice);
-            SetupChannelMock(m_mockDiscordClient, m_mockChatChannel, ChatId, ChatName, BotChannelType.Text);
+            SetupChannelMock(m_mockDiscordClient, m_mockControlChannel, ControlId, ControlName, false);
+            SetupChannelMock(m_mockDiscordClient, m_mockTownSquareChannel, TownSquareId, TownSquareName, true);
+            SetupChannelMock(m_mockDiscordClient, m_mockChatChannel, ChatId, ChatName, false);
             SetupChannelCategoryMock(m_mockDiscordClient, m_mockDayChannelCategory, DayCategoryId, DayCategoryName);
             SetupChannelCategoryMock(m_mockDiscordClient, m_mockNightChannelCategory, NightCategoryId, NightCategoryName);
 
@@ -56,121 +57,26 @@ namespace Test.Bot.DSharp
             m_mockTownRecord.SetupGet(tr => tr.NightCategory).Returns(NightCategoryName);
             m_mockTownRecord.SetupGet(tr => tr.NightCategoryId).Returns(NightCategoryId);
 
-            static void SetupChannelMock(Mock<IDiscordClient> clientMock, Mock<IChannel> channelMock, ulong channelId, string channelName, BotChannelType channelType)
+            static void SetupChannelMock(Mock<IDiscordClient> clientMock, Mock<IChannel> channelMock, ulong channelId, string channelName, bool expectedVoice)
             {
                 channelMock.SetupGet(c => c.Id).Returns(channelId);
                 channelMock.SetupGet(c => c.Name).Returns(channelName);
-                clientMock.Setup(c => c.GetChannelAsync(It.Is<ulong>(id => id == channelId), It.Is<string>(s => s == channelName), It.Is<BotChannelType>(ct => ct == channelType))).ReturnsAsync(new GetChannelResult(channelMock.Object, ChannelUpdateRequired.None));
-                clientMock.Setup(c => c.GetChannelAsync(It.Is<ulong>(id => id == MismatchedId), It.Is<string>(s => s == channelName), It.Is<BotChannelType>(ct => ct == channelType))).ReturnsAsync(new GetChannelResult(channelMock.Object, ChannelUpdateRequired.Id));
-                clientMock.Setup(c => c.GetChannelAsync(It.Is<ulong>(id => id == channelId), It.Is<string>(s => s == MismatchedName), It.Is<BotChannelType>(ct => ct == channelType))).ReturnsAsync(new GetChannelResult(channelMock.Object, ChannelUpdateRequired.Name));
-
-                var otherType = channelType == BotChannelType.Text ? BotChannelType.Voice : BotChannelType.Text;
-                clientMock.Setup(c => c.GetChannelAsync(It.Is<ulong>(id => id == channelId), It.Is<string>(s => s == channelName), It.Is<BotChannelType>(ct => ct == otherType))).ReturnsAsync(new GetChannelResult(null, ChannelUpdateRequired.None));
+                clientMock.Setup(c => c.GetChannelAsync(It.Is<ulong>(id => id == channelId))).ReturnsAsync(channelMock.Object);
             }
 
             static void SetupChannelCategoryMock(Mock<IDiscordClient> clientMock, Mock<IChannelCategory> channelMock, ulong channelId, string channelName)
             {
                 channelMock.SetupGet(c => c.Id).Returns(channelId);
                 channelMock.SetupGet(c => c.Name).Returns(channelName);
-                clientMock.Setup(c => c.GetChannelCategoryAsync(It.Is<ulong>(id => id == channelId), It.Is<string>(s => s == channelName))).ReturnsAsync(new GetChannelCategoryResult(channelMock.Object, ChannelUpdateRequired.None));
-                clientMock.Setup(c => c.GetChannelCategoryAsync(It.Is<ulong>(id => id == MismatchedId), It.Is<string>(s => s == channelName))).ReturnsAsync(new GetChannelCategoryResult(channelMock.Object, ChannelUpdateRequired.Id));
-                clientMock.Setup(c => c.GetChannelCategoryAsync(It.Is<ulong>(id => id == channelId), It.Is<string>(s => s == MismatchedName))).ReturnsAsync(new GetChannelCategoryResult(channelMock.Object, ChannelUpdateRequired.Name));
+                clientMock.Setup(c => c.GetChannelCategoryAsync(It.Is<ulong>(id => id == channelId))).ReturnsAsync(channelMock.Object);
             }
 
             var mockFactory = RegisterMock(new Mock<IDiscordClientFactory>());
             mockFactory.Setup(f => f.CreateClient(It.IsAny<DiscordConfiguration>())).Returns(m_mockDiscordClient.Object);
+
+            m_mockTownDb.Setup(db => db.UpdateTownAsync(It.IsAny<ITown>())).ReturnsAsync(true);
         }
 
-        [Fact]
-        public void ControlChannelTypeMismatch_NullReturnChannel() => TestChannelTypeMismatch(m_mockControlChannel.Object, BotChannelType.Text);
-
-        [Fact]
-        public void ChatChannelTypeMismatch_NullReturnChannel() => TestChannelTypeMismatch(m_mockChatChannel.Object, BotChannelType.Text);
-
-        [Fact]
-        public void TownSquareChannelTypeMismatch_NullReturnChannel() => TestChannelTypeMismatch(m_mockTownSquareChannel.Object, BotChannelType.Voice);
-
-        private void TestChannelTypeMismatch(IChannel channel, BotChannelType channelType)
-        {
-            var client = new DSharpClient(GetServiceProvider());
-            var testType = channelType == BotChannelType.Text ? BotChannelType.Voice : BotChannelType.Text;
-            var channelTask = client.GetChannelAsync(channel.Id, channel.Name, testType);
-            channelTask.Wait(50);
-            Assert.True(channelTask.IsCompleted);
-            Assert.Null(channelTask.Result.Channel);
-        }
-
-        [Fact]
-        public void ControlChannelNameMismatch_RequestsUpdate() => TestChannelNameMismatch(m_mockControlChannel.Object, BotChannelType.Text);
-
-        [Fact]
-        public void ChatChannelNameMismatch_RequestsUpdate() => TestChannelNameMismatch(m_mockChatChannel.Object, BotChannelType.Text);
-
-        [Fact]
-        public void TownSquareChannelNameMismatch_RequestsUpdate() => TestChannelNameMismatch(m_mockTownSquareChannel.Object, BotChannelType.Voice);
-
-        private void TestChannelNameMismatch(IChannel channel, BotChannelType channelType)
-        {
-            var client = new DSharpClient(GetServiceProvider());
-            var channelTask = client.GetChannelAsync(channel.Id, MismatchedName, channelType);
-            channelTask.Wait(50);
-            Assert.True(channelTask.IsCompleted);
-            Assert.Equal(channel, channelTask.Result.Channel);
-            Assert.Equal(ChannelUpdateRequired.Name, channelTask.Result.UpdateRequired);
-        }
-
-        [Fact]
-        public void DayCatNameMismatch_RequestsUpdate() => TestChannelCategoryNameMismatch(m_mockDayChannelCategory.Object);
-
-        [Fact]
-        public void NightCatNameMismatch_RequestsUpdate() => TestChannelCategoryNameMismatch(m_mockNightChannelCategory.Object);
-
-        private void TestChannelCategoryNameMismatch(IChannelCategory channelCategory)
-        {
-            var client = new DSharpClient(GetServiceProvider());
-            var channelCatTask = client.GetChannelCategoryAsync(channelCategory.Id, MismatchedName);
-            channelCatTask.Wait(50);
-            Assert.True(channelCatTask.IsCompleted);
-            Assert.Equal(channelCategory, channelCatTask.Result.Channel);
-            Assert.Equal(ChannelUpdateRequired.Name, channelCatTask.Result.UpdateRequired);
-        }
-
-        [Fact]
-        public void ControlChannelIdMismatch_RequestsUpdate() => TestChannelIdMismatch(m_mockControlChannel.Object, BotChannelType.Text);
-
-        [Fact]
-        public void ChatChannelIdMismatch_RequestsUpdate() => TestChannelIdMismatch(m_mockChatChannel.Object, BotChannelType.Text);
-
-        [Fact]
-        public void TownSquareChannelIdMismatch_RequestsUpdate() => TestChannelIdMismatch(m_mockTownSquareChannel.Object, BotChannelType.Voice);
-
-        private void TestChannelIdMismatch(IChannel channel, BotChannelType channelType)
-        {
-            var client = new DSharpClient(GetServiceProvider());
-            var channelTask = client.GetChannelAsync(MismatchedId, channel.Name, channelType);
-            channelTask.Wait(50);
-            Assert.True(channelTask.IsCompleted);
-            Assert.Equal(channel, channelTask.Result.Channel);
-            Assert.Equal(ChannelUpdateRequired.Id, channelTask.Result.UpdateRequired);
-        }
-
-        [Fact]
-        public void DayCatIdMismatch_RequestsUpdate() => TestChannelCategoryIdMismatch(m_mockDayChannelCategory.Object);
-
-        [Fact]
-        public void NightCatIdMismatch_RequestsUpdate() => TestChannelCategoryIdMismatch(m_mockNightChannelCategory.Object);
-
-        private void TestChannelCategoryIdMismatch(IChannelCategory channelCategory)
-        {
-            var client = new DSharpClient(GetServiceProvider());
-            var channelCatTask = client.GetChannelCategoryAsync(MismatchedId, channelCategory.Name);
-            channelCatTask.Wait(50);
-            Assert.True(channelCatTask.IsCompleted);
-            Assert.Equal(channelCategory, channelCatTask.Result.Channel);
-            Assert.Equal(ChannelUpdateRequired.Id, channelCatTask.Result.UpdateRequired);
-        }
-
-        /*
         [Fact]
         public void TownResolveChatNameOff_RequestsUpdate()
         {
@@ -178,8 +84,8 @@ namespace Test.Bot.DSharp
             var resolveTask = tr.ResolveTownAsync(m_mockTownRecord.Object);
             resolveTask.Wait(50);
             Assert.True(resolveTask.IsCompleted);
-            
+
+            m_mockTownDb.Verify(db => db.UpdateTownAsync(It.IsAny<ITown>()), Times.Once);
         }
-        */
     }
 }

--- a/Test.Bot.DSharp/TestChannelRetrieval.cs
+++ b/Test.Bot.DSharp/TestChannelRetrieval.cs
@@ -4,6 +4,8 @@ using Bot.Core;
 using Bot.DSharp;
 using DSharpPlus;
 using Moq;
+using System;
+using System.Collections.Generic;
 using Test.Bot.Base;
 using Xunit;
 
@@ -11,15 +13,18 @@ namespace Test.Bot.DSharp
 {
     public class TestChannelRetrieval : TestBase
     {
-        private readonly Mock<IDiscordClient> m_mockDiscordClient = new(MockBehavior.Strict);
+        private readonly Mock<IBotClient> m_mockClient = new(MockBehavior.Strict);
 
         private readonly Mock<IChannel> m_mockControlChannel = new(MockBehavior.Strict);
         private readonly Mock<IChannel> m_mockTownSquareChannel = new(MockBehavior.Strict);
         private readonly Mock<IChannel> m_mockChatChannel = new(MockBehavior.Strict);
         private readonly Mock<IChannelCategory> m_mockDayChannelCategory = new(MockBehavior.Strict);
         private readonly Mock<IChannelCategory> m_mockNightChannelCategory = new(MockBehavior.Strict);
-        private readonly Mock<ITownRecord> m_mockTownRecord = new(MockBehavior.Loose);
+        private readonly Mock<ITownRecord> m_mockTownRecord = new(MockBehavior.Strict);
         private readonly Mock<ITownDatabase> m_mockTownDb = new(MockBehavior.Strict);
+        private readonly Mock<IGuild> m_mockGuild = new(MockBehavior.Strict);
+        private readonly Mock<IRole> m_mockStorytellerRole = new(MockBehavior.Strict);
+        private readonly Mock<IRole> m_mockVillagerRole = new(MockBehavior.Strict);
 
         private const string MismatchedName = "mismatched name";
         private const string ControlName = "control chan";
@@ -34,17 +39,23 @@ namespace Test.Bot.DSharp
         private const ulong ChatId = 3;
         private const ulong DayCategoryId = 4;
         private const ulong NightCategoryId = 5;
+        private const ulong StorytellerRoleId = 6;
+        private const ulong VillagerRoleId = 7;
+        private const ulong GuildId = 77;
 
         public TestChannelRetrieval()
         {
+            RegisterMock(m_mockClient);
+            RegisterMock(m_mockTownDb);
+
             var env = RegisterMock(new Mock<IEnvironment>());
             env.Setup(e => e.GetEnvironmentVariable(It.IsAny<string>())).Returns("env var");
 
-            SetupChannelMock(m_mockDiscordClient, m_mockControlChannel, ControlId, ControlName, false);
-            SetupChannelMock(m_mockDiscordClient, m_mockTownSquareChannel, TownSquareId, TownSquareName, true);
-            SetupChannelMock(m_mockDiscordClient, m_mockChatChannel, ChatId, ChatName, false);
-            SetupChannelCategoryMock(m_mockDiscordClient, m_mockDayChannelCategory, DayCategoryId, DayCategoryName);
-            SetupChannelCategoryMock(m_mockDiscordClient, m_mockNightChannelCategory, NightCategoryId, NightCategoryName);
+            SetupChannelMock(m_mockClient, m_mockControlChannel, ControlId, ControlName, false);
+            SetupChannelMock(m_mockClient, m_mockTownSquareChannel, TownSquareId, TownSquareName, true);
+            SetupChannelMock(m_mockClient, m_mockChatChannel, ChatId, ChatName, false);
+            SetupChannelCategoryMock(m_mockClient, m_mockDayChannelCategory, DayCategoryId, DayCategoryName);
+            SetupChannelCategoryMock(m_mockClient, m_mockNightChannelCategory, NightCategoryId, NightCategoryName);
 
             m_mockTownRecord.SetupGet(tr => tr.ControlChannel).Returns(ControlName);
             m_mockTownRecord.SetupGet(tr => tr.ControlChannelId).Returns(ControlId);
@@ -56,36 +67,75 @@ namespace Test.Bot.DSharp
             m_mockTownRecord.SetupGet(tr => tr.DayCategoryId).Returns(DayCategoryId);
             m_mockTownRecord.SetupGet(tr => tr.NightCategory).Returns(NightCategoryName);
             m_mockTownRecord.SetupGet(tr => tr.NightCategoryId).Returns(NightCategoryId);
+            m_mockTownRecord.SetupGet(tr => tr.StorytellerRoleId).Returns(StorytellerRoleId);
+            m_mockTownRecord.SetupGet(tr => tr.VillagerRoleId).Returns(VillagerRoleId);
+            m_mockTownRecord.SetupGet(tr => tr.GuildId).Returns(GuildId);
 
-            static void SetupChannelMock(Mock<IDiscordClient> clientMock, Mock<IChannel> channelMock, ulong channelId, string channelName, bool expectedVoice)
+            static void SetupChannelMock(Mock<IBotClient> clientMock, Mock<IChannel> channelMock, ulong channelId, string channelName, bool expectedVoice)
             {
                 channelMock.SetupGet(c => c.Id).Returns(channelId);
                 channelMock.SetupGet(c => c.Name).Returns(channelName);
+                channelMock.SetupGet(c => c.IsVoice).Returns(expectedVoice);
                 clientMock.Setup(c => c.GetChannelAsync(It.Is<ulong>(id => id == channelId))).ReturnsAsync(channelMock.Object);
             }
 
-            static void SetupChannelCategoryMock(Mock<IDiscordClient> clientMock, Mock<IChannelCategory> channelMock, ulong channelId, string channelName)
+            static void SetupChannelCategoryMock(Mock<IBotClient> clientMock, Mock<IChannelCategory> channelMock, ulong channelId, string channelName)
             {
                 channelMock.SetupGet(c => c.Id).Returns(channelId);
                 channelMock.SetupGet(c => c.Name).Returns(channelName);
                 clientMock.Setup(c => c.GetChannelCategoryAsync(It.Is<ulong>(id => id == channelId))).ReturnsAsync(channelMock.Object);
             }
 
-            var mockFactory = RegisterMock(new Mock<IDiscordClientFactory>());
-            mockFactory.Setup(f => f.CreateClient(It.IsAny<DiscordConfiguration>())).Returns(m_mockDiscordClient.Object);
+            m_mockClient.Setup(c => c.GetGuildAsync(It.Is<ulong>(id => id == GuildId))).ReturnsAsync(m_mockGuild.Object);
+
+            Dictionary<ulong, IRole> roleDict = new()
+            {
+                { StorytellerRoleId, m_mockStorytellerRole.Object },
+                { VillagerRoleId, m_mockVillagerRole.Object },
+            };
+            m_mockGuild.SetupGet(g => g.Id).Returns(GuildId);
+            m_mockGuild.SetupGet(g => g.Roles).Returns(roleDict);
 
             m_mockTownDb.Setup(db => db.UpdateTownAsync(It.IsAny<ITown>())).ReturnsAsync(true);
         }
 
         [Fact]
+        public void TownResolve_AllCorrect_NoRequestsUpdate()
+        {
+            TestResolve_VerifyTownNotUpdated();
+        }
+
+        [Fact]
         public void TownResolveChatNameOff_RequestsUpdate()
+        {
+            m_mockChatChannel.SetupGet(c => c.Name).Returns(MismatchedName);
+            TestResolve_VerifyTownUpdated();
+        }
+
+        private void TestResolve_VerifyTownUpdated() => TestResolve_VerifyTownUpdatedTimes(Times.Once());
+        private void TestResolve_VerifyTownNotUpdated() => TestResolve_VerifyTownUpdatedTimes(Times.Never());
+
+        private void TestResolve_VerifyTownUpdatedTimes(Times numTimes)
         {
             var tr = new TownResolver(GetServiceProvider());
             var resolveTask = tr.ResolveTownAsync(m_mockTownRecord.Object);
             resolveTask.Wait(50);
             Assert.True(resolveTask.IsCompleted);
 
-            m_mockTownDb.Verify(db => db.UpdateTownAsync(It.IsAny<ITown>()), Times.Once);
+            m_mockTownDb.Verify(db => db.UpdateTownAsync(It.Is<ITown>(t => UpdatedTownMatches(t))), numTimes);
+        }
+
+        private bool UpdatedTownMatches(ITown update)
+        {
+            return
+                update.Guild == m_mockGuild.Object &&
+                update.TownSquare == m_mockTownSquareChannel.Object &&
+                update.ChatChannel == m_mockChatChannel.Object &&
+                update.ControlChannel == m_mockControlChannel.Object &&
+                update.DayCategory == m_mockDayChannelCategory.Object &&
+                update.NightCategory == m_mockNightChannelCategory.Object &&
+                update.StorytellerRole == m_mockStorytellerRole.Object &&
+                update.VillagerRole == m_mockVillagerRole.Object;
         }
     }
 }

--- a/Test.Bot.DSharp/TestChannelRetrieval.cs
+++ b/Test.Bot.DSharp/TestChannelRetrieval.cs
@@ -157,7 +157,7 @@ namespace Test.Bot.DSharp
         private void TestResolve_VerifyTownNotUpdated() => TestResolve_VerifyTownUpdatedTimes(Times.Never());
 
         [Fact]
-        public void TestResolve_ChatVoiceMismatch_NullChat()
+        public void TestResolve_ChatVoiceMismatch_NullChannel()
         {
             m_mockChatChannel.SetupGet(c => c.IsVoice).Returns(true);
             var town = PerformResolve();
@@ -166,7 +166,7 @@ namespace Test.Bot.DSharp
         }
 
         [Fact]
-        public void TestResolve_ControlVoiceMismatch_NullChat()
+        public void TestResolve_ControlVoiceMismatch_NullChannel()
         {
             m_mockControlChannel.SetupGet(c => c.IsVoice).Returns(true);
             var town = PerformResolve();
@@ -175,7 +175,7 @@ namespace Test.Bot.DSharp
         }
 
         [Fact]
-        public void TestResolve_TownSquareVoiceMismatch_NullChat()
+        public void TestResolve_TownSquareVoiceMismatch_NullChannel()
         {
             m_mockTownSquareChannel.SetupGet(c => c.IsVoice).Returns(false);
             var town = PerformResolve();

--- a/Test.Bot.DSharp/TestChannelRetrieval.cs
+++ b/Test.Bot.DSharp/TestChannelRetrieval.cs
@@ -1,10 +1,7 @@
 ﻿using Bot.Api;
 using Bot.Api.Database;
 using Bot.Core;
-using Bot.DSharp;
-using DSharpPlus;
 using Moq;
-using System;
 using System.Collections.Generic;
 using Test.Bot.Base;
 using Xunit;
@@ -51,11 +48,11 @@ namespace Test.Bot.DSharp
             var env = RegisterMock(new Mock<IEnvironment>());
             env.Setup(e => e.GetEnvironmentVariable(It.IsAny<string>())).Returns("env var");
 
-            SetupChannelMock(m_mockClient, m_mockControlChannel, ControlId, ControlName, false);
-            SetupChannelMock(m_mockClient, m_mockTownSquareChannel, TownSquareId, TownSquareName, true);
-            SetupChannelMock(m_mockClient, m_mockChatChannel, ChatId, ChatName, false);
-            SetupChannelCategoryMock(m_mockClient, m_mockDayChannelCategory, DayCategoryId, DayCategoryName);
-            SetupChannelCategoryMock(m_mockClient, m_mockNightChannelCategory, NightCategoryId, NightCategoryName);
+            SetupChannelMock(m_mockGuild, m_mockControlChannel, ControlId, ControlName, false);
+            SetupChannelMock(m_mockGuild, m_mockTownSquareChannel, TownSquareId, TownSquareName, true);
+            SetupChannelMock(m_mockGuild, m_mockChatChannel, ChatId, ChatName, false);
+            SetupChannelCategoryMock(m_mockGuild, m_mockDayChannelCategory, DayCategoryId, DayCategoryName);
+            SetupChannelCategoryMock(m_mockGuild, m_mockNightChannelCategory, NightCategoryId, NightCategoryName);
 
             m_mockTownRecord.SetupGet(tr => tr.ControlChannel).Returns(ControlName);
             m_mockTownRecord.SetupGet(tr => tr.ControlChannelId).Returns(ControlId);
@@ -71,19 +68,19 @@ namespace Test.Bot.DSharp
             m_mockTownRecord.SetupGet(tr => tr.VillagerRoleId).Returns(VillagerRoleId);
             m_mockTownRecord.SetupGet(tr => tr.GuildId).Returns(GuildId);
 
-            static void SetupChannelMock(Mock<IBotClient> clientMock, Mock<IChannel> channelMock, ulong channelId, string channelName, bool expectedVoice)
+            static void SetupChannelMock(Mock<IGuild> guildMock, Mock<IChannel> channelMock, ulong channelId, string channelName, bool expectedVoice)
             {
                 channelMock.SetupGet(c => c.Id).Returns(channelId);
                 channelMock.SetupGet(c => c.Name).Returns(channelName);
                 channelMock.SetupGet(c => c.IsVoice).Returns(expectedVoice);
-                clientMock.Setup(c => c.GetChannelAsync(It.Is<ulong>(id => id == channelId))).ReturnsAsync(channelMock.Object);
+                guildMock.Setup(c => c.GetChannel(It.Is<ulong>(id => id == channelId))).Returns(channelMock.Object);
             }
 
-            static void SetupChannelCategoryMock(Mock<IBotClient> clientMock, Mock<IChannelCategory> channelMock, ulong channelId, string channelName)
+            static void SetupChannelCategoryMock(Mock<IGuild> guildMock, Mock<IChannelCategory> channelMock, ulong channelId, string channelName)
             {
                 channelMock.SetupGet(c => c.Id).Returns(channelId);
                 channelMock.SetupGet(c => c.Name).Returns(channelName);
-                clientMock.Setup(c => c.GetChannelCategoryAsync(It.Is<ulong>(id => id == channelId))).ReturnsAsync(channelMock.Object);
+                guildMock.Setup(c => c.GetChannelCategory(It.Is<ulong>(id => id == channelId))).Returns(channelMock.Object);
             }
 
             m_mockClient.Setup(c => c.GetGuildAsync(It.Is<ulong>(id => id == GuildId))).ReturnsAsync(m_mockGuild.Object);

--- a/Test.Bot.DSharp/TestChannelRetrieval.cs
+++ b/Test.Bot.DSharp/TestChannelRetrieval.cs
@@ -106,9 +106,33 @@ namespace Test.Bot.DSharp
         }
 
         [Fact]
-        public void TownResolveChatNameOff_RequestsUpdate()
+        public void TownResolve_ChatNameOff_RequestsUpdate() => TestResolve_ChannelNameOff(m_mockChatChannel);
+        [Fact]
+        public void TownResolve_TownSquareNameOff_RequestsUpdate() => TestResolve_ChannelNameOff(m_mockTownSquareChannel);
+        [Fact]
+        public void TownResolve_ControlNameOff_RequestsUpdate() => TestResolve_ChannelNameOff(m_mockControlChannel);
+        [Fact]
+        public void TownResolve_DayCategoryNameOff_RequestsUpdate() => TestResolve_ChannelCategoryNameOff(m_mockDayChannelCategory);
+        [Fact]
+        public void TownResolve_NightCategoryNameOff_RequestsUpdate() => TestResolve_ChannelCategoryNameOff(m_mockNightChannelCategory);
+
+
+        private void TestResolve_ChannelNameOff(Mock<IChannel> channel)
         {
-            m_mockChatChannel.SetupGet(c => c.Name).Returns(MismatchedName);
+            channel.SetupGet(c => c.Name).Returns(MismatchedName);
+            TestResolve_VerifyTownUpdated();
+        }
+
+        private void TestResolve_ChannelCategoryNameOff(Mock<IChannelCategory> channelCategory)
+        {
+            channelCategory.SetupGet(c => c.Name).Returns(MismatchedName);
+            TestResolve_VerifyTownUpdated();
+        }
+
+        [Fact]
+        public void TownResolveTownSquareNameOff_RequestsUpdate()
+        {
+            m_mockTownSquareChannel.SetupGet(c => c.Name).Returns(MismatchedName);
             TestResolve_VerifyTownUpdated();
         }
 

--- a/Test.Bot.DSharp/TestChannelRetrieval.cs
+++ b/Test.Bot.DSharp/TestChannelRetrieval.cs
@@ -94,7 +94,7 @@ namespace Test.Bot.DSharp
             m_mockGuild.SetupGet(g => g.Roles).Returns(roleDict);
             IChannel[] channels = new[] { m_mockChatChannel.Object, m_mockControlChannel.Object, m_mockTownSquareChannel.Object };
             IChannelCategory[] channelCategories = new[] { m_mockDayChannelCategory.Object, m_mockNightChannelCategory.Object };
-            m_mockGuild.SetupGet(g => g.Channels).Returns(channels);
+            m_mockDayChannelCategory.SetupGet(cc => cc.Channels).Returns(channels);
             m_mockGuild.SetupGet(g => g.ChannelCategories).Returns(channelCategories);
 
             m_mockTownDb.Setup(db => db.UpdateTownAsync(It.IsAny<ITown>())).ReturnsAsync(true);
@@ -130,25 +130,27 @@ namespace Test.Bot.DSharp
         }
 
         [Fact]
-        public void TownResolve_ChatIdOff_RequestsUpdate() => TestResolve_ChannelIdOff(m_mockChatChannel);
+        public void TownResolve_ChatIdOff_RequestsUpdate() => TestResolve_ChannelIdOff(ChatId, m_mockChatChannel);
         [Fact]
-        public void TownResolve_TownSquareIdOff_RequestsUpdate() => TestResolve_ChannelIdOff(m_mockTownSquareChannel);
+        public void TownResolve_TownSquareIdOff_RequestsUpdate() => TestResolve_ChannelIdOff(TownSquareId, m_mockTownSquareChannel);
         [Fact]
-        public void TownResolve_ControlIdOff_RequestsUpdate() => TestResolve_ChannelIdOff(m_mockControlChannel);
+        public void TownResolve_ControlIdOff_RequestsUpdate() => TestResolve_ChannelIdOff(ControlId, m_mockControlChannel);
         [Fact]
-        public void TownResolve_DayCategoryIdOff_RequestsUpdate() => TestResolve_ChannelCategoryIdOff(m_mockDayChannelCategory);
+        public void TownResolve_DayCategoryIdOff_RequestsUpdate() => TestResolve_ChannelCategoryIdOff(DayCategoryId, m_mockDayChannelCategory);
         [Fact]
-        public void TownResolve_NightCategoryIdOff_RequestsUpdate() => TestResolve_ChannelCategoryIdOff(m_mockNightChannelCategory);
+        public void TownResolve_NightCategoryIdOff_RequestsUpdate() => TestResolve_ChannelCategoryIdOff(NightCategoryId, m_mockNightChannelCategory);
 
 
-        private void TestResolve_ChannelIdOff(Mock<IChannel> channel)
+        private void TestResolve_ChannelIdOff(ulong originalId, Mock<IChannel> channel)
         {
+            m_mockGuild.Setup(g => g.GetChannel(It.Is<ulong>(l => l == originalId))).Returns((IChannel?)null);
             channel.SetupGet(c => c.Id).Returns(MismatchedId);
             TestResolve_VerifyTownUpdated();
         }
 
-        private void TestResolve_ChannelCategoryIdOff(Mock<IChannelCategory> channelCategory)
+        private void TestResolve_ChannelCategoryIdOff(ulong originalId, Mock<IChannelCategory> channelCategory)
         {
+            m_mockGuild.Setup(g => g.GetChannelCategory(It.Is<ulong>(l => l == originalId))).Returns((IChannelCategory?)null);
             channelCategory.SetupGet(c => c.Id).Returns(MismatchedId);
             TestResolve_VerifyTownUpdated();
         }


### PR DESCRIPTION
When a channel has its name change but its ID remain the same, the bot can now find it.
When a channel is deleted and then re-added (so its ID changes but its name remains the same), the bot can now find it.
In either case, the DB is also updated the reflect the new name / ID