### PR TITLE
Updating overwrite clear to do so without awaiting in the loop.

### DIFF
--- a/Bot.DSharp/DSharpChannel.cs
+++ b/Bot.DSharp/DSharpChannel.cs
@@ -25,12 +25,20 @@ namespace Bot.DSharp
 
 		public string Name => Wrapped.Name;
 
-		public async Task ClearOverwrites()
+		public Task ClearOverwrites()
         {
-			foreach(var o in Wrapped.PermissionOverwrites)
-            {
-				await o.DeleteAsync();
-            }
+			var deletes = Wrapped.PermissionOverwrites.Select(DeletePermissionOverwriteAsync);
+			return Task.WhenAll(deletes);
+        }
+
+        private async Task DeletePermissionOverwriteAsync(DiscordOverwrite overwrite)
+		{
+			try
+			{
+				await ExceptionWrap.WrapExceptionsAsync(() => overwrite.DeleteAsync());
+			}
+			catch (Bot.Api.UnauthorizedException)
+			{ }
         }
 
         public async Task AddOverwriteAsync(IMember m, Permissions allow, Permissions deny = Permissions.None)

--- a/Bot.DSharp/DSharpChannelCategory.cs
+++ b/Bot.DSharp/DSharpChannelCategory.cs
@@ -19,12 +19,20 @@ namespace Bot.DSharp
 
 		public string Name => Wrapped.Name;
 
-		public async Task ClearOverwrites()
+		public Task ClearOverwrites()
 		{
-			foreach (var o in Wrapped.PermissionOverwrites)
+			var deletes = Wrapped.PermissionOverwrites.Select(DeletePermissionOverwriteAsync);
+			return Task.WhenAll(deletes);
+		}
+
+		private async Task DeletePermissionOverwriteAsync(DiscordOverwrite overwrite)
+		{
+			try
 			{
-				await o.DeleteAsync();
+				await ExceptionWrap.WrapExceptionsAsync(() => overwrite.DeleteAsync());
 			}
+			catch (Bot.Api.UnauthorizedException)
+			{ }
 		}
 
 		public async Task AddOverwriteAsync(IMember m, Permissions allow, Permissions deny = Permissions.None)


### PR DESCRIPTION
 This should avoid allowing the permissions to change mid-enumeration, and should fix #147.

Also updating it to account for unauthorized access, which happens when an admin is in the room.