### PR TITLE
Adding verbose logging to bot

### DIFF
--- a/Bot.Api/ITask.cs
+++ b/Bot.Api/ITask.cs
@@ -1,10 +1,29 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Bot.Api
 {
     public interface ITask
     {
-        Task Delay(TimeSpan millisecondsDelay);
+        Task Delay(TimeSpan span, CancellationToken ct);
+    }
+
+    public static class ITaskExtensions
+    {
+        public static Task Delay(this ITask @this, int milliseconds)
+        {
+            return @this.Delay(TimeSpan.FromMilliseconds(milliseconds), CancellationToken.None);
+        }
+
+        public static Task Delay(this ITask @this, TimeSpan span)
+        {
+            return @this.Delay(span, CancellationToken.None);
+        }  
+
+        public static Task Delay(this ITask @this, int milliseconds, CancellationToken ct)
+        {
+            return @this.Delay(TimeSpan.FromMilliseconds(milliseconds), ct);
+        }            
     }
 }

--- a/Bot.Core/BotGameplay.cs
+++ b/Bot.Core/BotGameplay.cs
@@ -312,9 +312,12 @@ namespace Bot.Core
             var town = await GetValidTownOrLogErrorAsync(game.TownKey, processLog);
             if (town == null)
                 return "Failed to find a valid town!";
+
+            processLog.LogVerbose($"Moving players to Town Square for town: {game.TownKey}");
             await MoveActivePlayersToTownSquare(game, town, processLog);
 
             // Remove member-specific cottage view permissions that may have been added in the Night phase
+            processLog.LogVerbose($"Removing cottage permission overwrites for town: {game.TownKey}");
             var permissionTasks = new List<Task>();
             if (town.NightCategory != null)
                 foreach (var cottage in town.NightCategory.Channels)
@@ -324,6 +327,7 @@ namespace Bot.Core
             await m_gameMetricsDatabase.RecordDayAsync(game.TownKey, m_dateTime.Now);
             await m_commandMetricsDatabase.RecordCommand("day", m_dateTime.Now);
 
+            processLog.LogVerbose($"Day phase complete for town: {game.TownKey}");
             return "Moved all players from Cottages back to Town Square!";
         }
 
@@ -333,11 +337,13 @@ namespace Bot.Core
             if (town == null)
                 return "Failed to find a valid town!";
 
+            processLog.LogVerbose($"Moving players to Town Square for town: {game.TownKey}");
             await MoveActivePlayersToTownSquare(game, town, processLog);
 
             await m_gameMetricsDatabase.RecordVoteAsync(game.TownKey, m_dateTime.Now);
             await m_commandMetricsDatabase.RecordCommand("vote", m_dateTime.Now);
 
+            processLog.LogVerbose($"Vote phase complete for town: {game.TownKey}");
             return "Moved all players to Town Square for voting!";
         }
 

--- a/Bot.Core/BotGameplay.cs
+++ b/Bot.Core/BotGameplay.cs
@@ -1,6 +1,7 @@
 ﻿using Bot.Api;
 using Bot.Api.Database;
 using Bot.Core.Interaction;
+using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,6 +17,7 @@ namespace Bot.Core
         private readonly IGameMetricDatabase m_gameMetricsDatabase;
         private readonly ICommandMetricDatabase m_commandMetricsDatabase;
         private readonly IDateTime m_dateTime;
+        private readonly ILogger m_logger;
 
         public const string NoGameInProgressMessage = "Could not start a game. This might mean there was a permission issue, or it could mean nobody is currently in the Town channels. Are you ready to play?";
 
@@ -28,6 +30,7 @@ namespace Bot.Core
             services.Inject(out m_gameMetricsDatabase);
             services.Inject(out m_commandMetricsDatabase);
             services.Inject(out m_dateTime);
+            services.Inject(out m_logger);
 
             m_townCleanup.CleanupRequested += TownCleanup_CleanupRequested;
         }
@@ -84,7 +87,7 @@ namespace Bot.Core
 
         private void TownCleanup_CleanupRequested(object? sender, TownCleanupRequestedArgs e)
         {
-            var logger = new ProcessLogger();
+            var logger = new ProcessLogger(m_logger);
             EndGameUnsafeAsync(e.TownKey, logger).ConfigureAwait(continueOnCapturedContext: true);
         }
 
@@ -331,7 +334,7 @@ namespace Bot.Core
 
         public async Task PerformVoteAsync(TownKey townKey)
         {
-            var logger = new ProcessLogger();
+            var logger = new ProcessLogger(m_logger);
 
             var game = await CreateGameFromDiscordState(townKey, null, logger);
             

--- a/Bot.Core/BotMessaging.cs
+++ b/Bot.Core/BotMessaging.cs
@@ -1,6 +1,7 @@
 ﻿using Bot.Api;
 using Bot.Api.Database;
 using Bot.Core.Interaction;
+using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,12 +14,14 @@ namespace Bot.Core
         private readonly ITownInteractionQueue m_townCommandQueue;
         private readonly ICommandMetricDatabase m_commandMetricsDatabase;
         private readonly IDateTime m_dateTime;
+        private readonly ILogger m_logger;
 
         public BotMessaging(IServiceProvider services)
         {
             services.Inject(out m_townCommandQueue);
             services.Inject(out m_commandMetricsDatabase);
             services.Inject(out m_dateTime);
+            services.Inject(out m_logger);
         }
 
         private const string DemonGreeting = "{0}: You are the **demon**. ";
@@ -69,7 +72,7 @@ namespace Bot.Core
 
         public async Task<string> SendEvilMessage(IMember demon, IReadOnlyCollection<IMember> minions)
         {
-            ProcessLogger logger = new();
+            ProcessLogger logger = new(m_logger);
             try
             {
                 await SendDemonMessage(new[] { demon }, minions, logger);
@@ -85,7 +88,7 @@ namespace Bot.Core
 
         public async Task<string> SendLegionMessage(IReadOnlyCollection<IMember> legions)
         {
-            ProcessLogger logger = new();
+            ProcessLogger logger = new(m_logger);
             try
             {
                 await SendDemonMessage(legions, Enumerable.Empty<IMember>().ToList(), logger);
@@ -100,7 +103,7 @@ namespace Bot.Core
 
         public async Task<string> SendLunaticMessage(IMember lunatic, IReadOnlyCollection<IMember> fakeMinions)
         {
-            ProcessLogger logger = new();
+            ProcessLogger logger = new(m_logger);
             try
             {
                 await SendDemonMessage(new[] { lunatic }, fakeMinions, logger);
@@ -115,7 +118,7 @@ namespace Bot.Core
 
         public async Task<string> SendMagicianMessage(IMember demon, IReadOnlyCollection<IMember> minions, IMember magician)
         {
-            ProcessLogger logger = new();
+            ProcessLogger logger = new(m_logger);
             try
             {
                 var fakeMinions = minions.ToList();

--- a/Bot.Core/IProcessLogger.cs
+++ b/Bot.Core/IProcessLogger.cs
@@ -5,10 +5,12 @@ namespace Bot.Api
 {
     public interface IProcessLogger
     {
-        public void LogException(Exception ex, string goal);
+        void LogException(Exception ex, string goal);
 
-        public void LogMessage(string msg);
+        void LogMessage(string msg);
 
-        public IReadOnlyCollection<string> Messages { get; }
+        void LogVerbose(string msg);
+
+        IReadOnlyCollection<string> Messages { get; }
     }
 }

--- a/Bot.Core/IProcessLogger.cs
+++ b/Bot.Core/IProcessLogger.cs
@@ -11,6 +11,8 @@ namespace Bot.Api
 
         void LogVerbose(string msg);
 
+        void EnableVerboseLogging();
+
         IReadOnlyCollection<string> Messages { get; }
     }
 }

--- a/Bot.Core/Interaction/BaseInteractionErrorHandler.cs
+++ b/Bot.Core/Interaction/BaseInteractionErrorHandler.cs
@@ -6,11 +6,18 @@ namespace Bot.Core.Interaction
 {
     public abstract class BaseInteractionErrorHandler<TKey> where TKey : notnull
     {
+        private readonly IProcessLoggerFactory m_processLoggerFactory;
+
+        public BaseInteractionErrorHandler(IServiceProvider serviceProvider)
+        {
+            serviceProvider.Inject(out m_processLoggerFactory);
+        }
+
         protected abstract string GetFriendlyStringForKey(TKey key);
 
         public async Task<InteractionResult> TryProcessReportingErrorsAsync(TKey key, IMember requester, Func<IProcessLogger, Task<InteractionResult>> process)
         {
-            var logger = new ProcessLogger();
+            var logger = m_processLoggerFactory.Create();
             InteractionResult result = "An error occurred processing this command - please check your private messages for a detailed report.";
             try
             {

--- a/Bot.Core/Interaction/GuildInteractionErrorHandler.cs
+++ b/Bot.Core/Interaction/GuildInteractionErrorHandler.cs
@@ -1,7 +1,13 @@
-﻿namespace Bot.Core.Interaction
+﻿using System;
+
+namespace Bot.Core.Interaction
 {
     public class GuildInteractionErrorHandler : BaseInteractionErrorHandler<ulong>, IGuildInteractionErrorHandler
     {
+        public GuildInteractionErrorHandler(IServiceProvider serviceProvider) 
+            : base(serviceProvider)
+        {}
+
         protected override string GetFriendlyStringForKey(ulong key) => $"Guild: `{key}`";
     }
 }

--- a/Bot.Core/Interaction/TownInteractionErrorHandler.cs
+++ b/Bot.Core/Interaction/TownInteractionErrorHandler.cs
@@ -1,9 +1,14 @@
 ﻿using Bot.Api;
+using System;
 
 namespace Bot.Core.Interaction
 {
     public class TownInteractionErrorHandler : BaseInteractionErrorHandler<TownKey>, ITownInteractionErrorHandler
     {
+        public TownInteractionErrorHandler(IServiceProvider serviceProvider) 
+            : base(serviceProvider)
+        {}
+
         protected override string GetFriendlyStringForKey(TownKey townKey) => $"Guild: `{townKey.GuildId}`\nChannel: `{townKey.ControlChannelId}`";
     }
 }

--- a/Bot.Core/ProcessLogger.cs
+++ b/Bot.Core/ProcessLogger.cs
@@ -45,6 +45,11 @@ namespace Bot.Core
             Serilog.Log.Debug("ProcessLogger message: {msg}", msg);
 		}
 
+        public void LogVerbose(string msg)
+        {
+            throw new NotImplementedException();
+        }
+
         public IReadOnlyCollection<string> Messages => m_messages;
 	}
 }

--- a/Bot.Core/ProcessLoggerFactory.cs
+++ b/Bot.Core/ProcessLoggerFactory.cs
@@ -1,4 +1,5 @@
 ﻿using Bot.Api;
+using Serilog;
 
 namespace Bot.Core
 {
@@ -9,6 +10,13 @@ namespace Bot.Core
 
     public class ProcessLoggerFactory : IProcessLoggerFactory
     {
-        public IProcessLogger Create() => new ProcessLogger();
+        private readonly ILogger m_logger;
+
+        public ProcessLoggerFactory(ILogger logger)
+        {
+            m_logger = logger;
+        }
+
+        public IProcessLogger Create() => new ProcessLogger(m_logger);
     }
 }

--- a/Bot.Core/ProcessLoggerFactory.cs
+++ b/Bot.Core/ProcessLoggerFactory.cs
@@ -1,0 +1,14 @@
+﻿using Bot.Api;
+
+namespace Bot.Core
+{
+    public interface IProcessLoggerFactory
+    {
+        IProcessLogger Create();
+    }
+
+    public class ProcessLoggerFactory : IProcessLoggerFactory
+    {
+        public IProcessLogger Create() => new ProcessLogger();
+    }
+}

--- a/Bot.Core/ServiceFactory.cs
+++ b/Bot.Core/ServiceFactory.cs
@@ -2,6 +2,7 @@
 using Bot.Base;
 using Bot.Core.Callbacks;
 using Bot.Core.Interaction;
+using Serilog;
 using System;
 using System.Threading;
 
@@ -19,7 +20,7 @@ namespace Bot.Core
             var shutdown = new ShutdownService(sp, applicationCancelToken);
             sp.AddService<IFinalShutdownService>(shutdown);
             sp.AddService<IShutdownPreventionService>(shutdown);
-            sp.AddService<IProcessLoggerFactory>(new ProcessLoggerFactory());
+            sp.AddService<IProcessLoggerFactory>(new ProcessLoggerFactory(sp.GetService<ILogger>()));
             sp.AddService<ITownInteractionErrorHandler>(new TownInteractionErrorHandler(sp));
             sp.AddService<IGuildInteractionErrorHandler>(new GuildInteractionErrorHandler(sp));
 

--- a/Bot.Core/ServiceFactory.cs
+++ b/Bot.Core/ServiceFactory.cs
@@ -19,8 +19,9 @@ namespace Bot.Core
             var shutdown = new ShutdownService(sp, applicationCancelToken);
             sp.AddService<IFinalShutdownService>(shutdown);
             sp.AddService<IShutdownPreventionService>(shutdown);
-            sp.AddService<ITownInteractionErrorHandler>(new TownInteractionErrorHandler());
-            sp.AddService<IGuildInteractionErrorHandler>(new GuildInteractionErrorHandler());
+            sp.AddService<IProcessLoggerFactory>(new ProcessLoggerFactory());
+            sp.AddService<ITownInteractionErrorHandler>(new TownInteractionErrorHandler(sp));
+            sp.AddService<IGuildInteractionErrorHandler>(new GuildInteractionErrorHandler(sp));
 
             sp.AddService<ICallbackSchedulerFactory>(new CallbackSchedulerFactory(sp));
             sp.AddService<IComponentService>(new ComponentService());

--- a/Bot.Main/Program.cs
+++ b/Bot.Main/Program.cs
@@ -73,6 +73,7 @@ namespace Bot.Main
         public static IServiceProvider RegisterServices()
         {
             var sp = new ServiceProvider();
+            sp.AddService(Log.Logger);
             sp.AddService<IDateTime>(new DateTimeStatic());
             sp.AddService<IEnvironment>(new ProgramEnvironment());
             sp.AddService<ITask>(new TaskStatic());

--- a/Bot.Main/TaskStatic.cs
+++ b/Bot.Main/TaskStatic.cs
@@ -1,11 +1,12 @@
 ﻿using Bot.Api;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Bot.Main
 {
     public class TaskStatic : ITask
     {
-        public Task Delay(TimeSpan delay) => Task.Delay(delay);
+        public Task Delay(TimeSpan delay, CancellationToken ct) => Task.Delay(delay, ct);
     }
 }

--- a/Test.Bot.Base/TestTaskHelper.cs
+++ b/Test.Bot.Base/TestTaskHelper.cs
@@ -10,14 +10,14 @@ namespace Test.Bot.Base
         {
             var t = runTask();
             t.Wait(50);
-            Assert.True(t.IsCompleted);
+            Assert.True(t.IsCompleted, "Task did not complete in time allotted");
         }
 
         public static T AssertCompletedTask<T>(Func<Task<T>> runTask)
         {
             var t = runTask();
             t.Wait(50);
-            Assert.True(t.IsCompleted);
+            Assert.True(t.IsCompleted, "Task did not complete in time allotted");
             return t.Result;
         }
     }

--- a/Test.Bot.Core/GameTestBase.cs
+++ b/Test.Bot.Core/GameTestBase.cs
@@ -76,13 +76,13 @@ namespace Test.Bot.Core
 
         public GameTestBase()
         {
+            m_processLoggerMock = new(MockBehavior.Strict);
             m_processLoggerMock.Setup(pl => pl.LogException(It.IsAny<Exception>(), It.IsAny<string>()));
             m_processLoggerMock.Setup(pl => pl.LogMessage(It.IsAny<string>()));
             m_processLoggerMock.Setup(pl => pl.LogVerbose(It.IsAny<string>()));
             m_processLoggerMock.Setup(pl => pl.EnableVerboseLogging());
             m_processLoggerMock.SetupGet(pl => pl.Messages).Returns(m_processLoggerMessages);
 
-            m_processLoggerMock = new(MockBehavior.Strict);
             m_processLoggerFactoryMock = RegisterMock(new Mock<IProcessLoggerFactory>(MockBehavior.Strict));
             m_processLoggerFactoryMock.Setup(plf => plf.Create()).Returns(m_processLoggerMock.Object);
 

--- a/Test.Bot.Core/GameTestBase.cs
+++ b/Test.Bot.Core/GameTestBase.cs
@@ -70,8 +70,17 @@ namespace Test.Bot.Core
         protected readonly Mock<IGameMetricDatabase> GameMetricDatabaseMock = new();
         protected readonly Mock<ICommandMetricDatabase> CommandMetricDatabaseMock = new();
 
+        protected readonly Mock<IProcessLogger> m_processLoggerMock;
+        protected readonly Mock<IProcessLoggerFactory> m_processLoggerFactoryMock;
+        protected readonly List<string> m_processLoggerMessages = new();
+
         public GameTestBase()
         {
+            m_processLoggerMock = new(MockBehavior.Strict);
+            m_processLoggerFactoryMock = RegisterMock(new Mock<IProcessLoggerFactory>(MockBehavior.Strict));
+            m_processLoggerFactoryMock.Setup(plf => plf.Create()).Returns(m_processLoggerMock.Object);
+            m_processLoggerMock.SetupGet(pl => pl.Messages).Returns(m_processLoggerMessages);
+
             RegisterMock(CallbackSchedulerFactoryMock);
             CallbackSchedulerFactoryMock
                 .Setup(csf => csf.CreateScheduler(It.IsAny<Func<TownKey, Task>>(), It.IsAny<TimeSpan>())).Returns(TownKeyCallbackSchedulerMock.Object)

--- a/Test.Bot.Core/GameTestBase.cs
+++ b/Test.Bot.Core/GameTestBase.cs
@@ -76,10 +76,15 @@ namespace Test.Bot.Core
 
         public GameTestBase()
         {
+            m_processLoggerMock.Setup(pl => pl.LogException(It.IsAny<Exception>(), It.IsAny<string>()));
+            m_processLoggerMock.Setup(pl => pl.LogMessage(It.IsAny<string>()));
+            m_processLoggerMock.Setup(pl => pl.LogVerbose(It.IsAny<string>()));
+            m_processLoggerMock.Setup(pl => pl.EnableVerboseLogging());
+            m_processLoggerMock.SetupGet(pl => pl.Messages).Returns(m_processLoggerMessages);
+
             m_processLoggerMock = new(MockBehavior.Strict);
             m_processLoggerFactoryMock = RegisterMock(new Mock<IProcessLoggerFactory>(MockBehavior.Strict));
             m_processLoggerFactoryMock.Setup(plf => plf.Create()).Returns(m_processLoggerMock.Object);
-            m_processLoggerMock.SetupGet(pl => pl.Messages).Returns(m_processLoggerMessages);
 
             RegisterMock(CallbackSchedulerFactoryMock);
             CallbackSchedulerFactoryMock

--- a/Test.Bot.Core/TestCallbackScheduler.cs
+++ b/Test.Bot.Core/TestCallbackScheduler.cs
@@ -2,6 +2,7 @@
 using Bot.Core.Callbacks;
 using Moq;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Test.Bot.Base;
 using Xunit;
@@ -26,7 +27,7 @@ namespace Test.Bot.Core
             RegisterMock(m_mockTask);
 
             m_mockDateTime.SetupGet(dt => dt.Now).Returns(() => m_currentTime);
-            m_mockTask.Setup(t => t.Delay(It.IsAny<TimeSpan>())).Returns(async () =>
+            m_mockTask.Setup(t => t.Delay(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>())).Returns(async () =>
             {
                 bool success = await m_delayReset.WaitOneAsync(TimeSpan.FromSeconds(2));
                 Assert.True(success);
@@ -102,7 +103,7 @@ namespace Test.Bot.Core
 
             helper.CancelCallback();
 
-            m_mockTask.Verify(t => t.Delay(It.Is<TimeSpan>(ts => ts == TimeSpan.FromSeconds(1))), Times.AtLeastOnce);
+            m_mockTask.Verify(t => t.Delay(It.Is<TimeSpan>(ts => ts == TimeSpan.FromSeconds(1)), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
             m_mockDateTime.VerifyGet(dt => dt.Now, Times.AtLeastOnce);
 
             AdvanceTime(TimeSpan.FromSeconds(10));
@@ -135,7 +136,7 @@ namespace Test.Bot.Core
             m_delayReset.Set();
             await helper.WaitCallbackAsync();
 
-            m_mockTask.Verify(t => t.Delay(It.Is<TimeSpan>(ts => ts == TimeSpan.FromSeconds(1))), Times.AtLeastOnce);
+            m_mockTask.Verify(t => t.Delay(It.Is<TimeSpan>(ts => ts == TimeSpan.FromSeconds(1)), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
             m_mockDateTime.VerifyGet(dt => dt.Now, Times.AtLeastOnce);
             Assert.Equal(1, helper.CallbackCount);
         }
@@ -149,7 +150,7 @@ namespace Test.Bot.Core
             await Task.Delay(10);
 
             m_mockDateTime.VerifyGet(dt => dt.Now, Times.Never);
-            m_mockTask.Verify(t => t.Delay(It.IsAny<TimeSpan>()), Times.Never);
+            m_mockTask.Verify(t => t.Delay(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [Fact]
@@ -164,7 +165,7 @@ namespace Test.Bot.Core
             await helper.WaitCallbackAsync();
 
             Assert.Equal(1, helper.CallbackCount);
-            m_mockTask.Verify(t => t.Delay(It.IsAny<TimeSpan>()), Times.Once, "Task not called once");
+            m_mockTask.Verify(t => t.Delay(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()), Times.Once, "Task not called once");
         }
 
         [Fact]
@@ -226,7 +227,7 @@ namespace Test.Bot.Core
 
             helper.CancelCallback();
 
-            m_mockTask.Verify(t => t.Delay(It.Is<TimeSpan>(ts => ts == TimeSpan.FromSeconds(1))), Times.AtLeastOnce);
+            m_mockTask.Verify(t => t.Delay(It.Is<TimeSpan>(ts => ts == TimeSpan.FromSeconds(1)), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
             m_mockDateTime.VerifyGet(dt => dt.Now, Times.AtLeastOnce);
 
             AdvanceTime(TimeSpan.FromSeconds(10));
@@ -259,7 +260,7 @@ namespace Test.Bot.Core
             m_delayReset.Set();
             await helper.WaitCallbackAsync();
 
-            m_mockTask.Verify(t => t.Delay(It.Is<TimeSpan>(ts => ts == TimeSpan.FromSeconds(1))), Times.AtLeastOnce);
+            m_mockTask.Verify(t => t.Delay(It.Is<TimeSpan>(ts => ts == TimeSpan.FromSeconds(1)), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
             m_mockDateTime.VerifyGet(dt => dt.Now, Times.AtLeastOnce);
             Assert.Equal(1, helper.CallbackCount);
         }
@@ -273,7 +274,7 @@ namespace Test.Bot.Core
             await Task.Delay(10);
 
             m_mockDateTime.VerifyGet(dt => dt.Now, Times.Never);
-            m_mockTask.Verify(t => t.Delay(It.IsAny<TimeSpan>()), Times.Never);
+            m_mockTask.Verify(t => t.Delay(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [Fact]
@@ -288,7 +289,7 @@ namespace Test.Bot.Core
             await helper.WaitCallbackAsync();
 
             Assert.Equal(1, helper.CallbackCount);
-            m_mockTask.Verify(t => t.Delay(It.IsAny<TimeSpan>()), Times.Once, "Task not called once");
+            m_mockTask.Verify(t => t.Delay(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()), Times.Once, "Task not called once");
         }
 
         private class CallbackHelperWithKey

--- a/Test.Bot.Core/TestCommandUtilities.cs
+++ b/Test.Bot.Core/TestCommandUtilities.cs
@@ -4,6 +4,7 @@ using Bot.Core.Interaction;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Test.Bot.Base;
 using Xunit;
@@ -25,12 +26,17 @@ namespace Test.Bot.Core
         private readonly Mock<IProcessLoggerFactory> m_processLoggerFactoryMock;
         private readonly List<string> m_processLoggerMessages = new();
 
+        private readonly Mock<ITask> m_taskMock;
+
         public TestCommandUtilities()
         {
             m_processLoggerMock = new(MockBehavior.Strict);
             m_processLoggerFactoryMock = RegisterMock(new Mock<IProcessLoggerFactory>(MockBehavior.Strict));
             m_processLoggerFactoryMock.Setup(plf => plf.Create()).Returns(m_processLoggerMock.Object);
             m_processLoggerMock.SetupGet(pl => pl.Messages).Returns(m_processLoggerMessages);
+
+            m_taskMock = RegisterMock(new Mock<ITask>(MockBehavior.Strict));
+            m_taskMock.Setup(t => t.Delay(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>())).Returns(Task.Delay(TimeSpan.FromMilliseconds(1)));
         }
 
         [Fact]

--- a/Test.Bot.Core/TestCommandUtilities.cs
+++ b/Test.Bot.Core/TestCommandUtilities.cs
@@ -3,6 +3,7 @@ using Bot.Core;
 using Bot.Core.Interaction;
 using Moq;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Test.Bot.Base;
 using Xunit;
@@ -13,7 +14,23 @@ namespace Test.Bot.Core
     {
         private class TestInteractionErrorHandler : BaseInteractionErrorHandler<int>
         {
+            public TestInteractionErrorHandler(IServiceProvider serviceProvider) 
+                : base(serviceProvider)
+            {}
+
             protected override string GetFriendlyStringForKey(int key) => key.ToString();
+        }
+
+        private readonly Mock<IProcessLogger> m_processLoggerMock;
+        private readonly Mock<IProcessLoggerFactory> m_processLoggerFactoryMock;
+        private readonly List<string> m_processLoggerMessages = new();
+
+        public TestCommandUtilities()
+        {
+            m_processLoggerMock = new(MockBehavior.Strict);
+            m_processLoggerFactoryMock = RegisterMock(new Mock<IProcessLoggerFactory>(MockBehavior.Strict));
+            m_processLoggerFactoryMock.Setup(plf => plf.Create()).Returns(m_processLoggerMock.Object);
+            m_processLoggerMock.SetupGet(pl => pl.Messages).Returns(m_processLoggerMessages);
         }
 
         [Fact]
@@ -23,25 +40,34 @@ namespace Test.Bot.Core
             Mock<Func<IProcessLogger, Task<InteractionResult>>> mockFunc = new();
             mockFunc.Setup(f => f.Invoke(It.IsAny<IProcessLogger>())).ReturnsAsync(InteractionResult.FromMessage("message"));
 
-            TestInteractionErrorHandler ih = new();
+            TestInteractionErrorHandler ih = new(GetServiceProvider());
             AssertCompletedTask(() => ih.TryProcessReportingErrorsAsync(123, mockRequester.Object, mockFunc.Object));
 
             mockFunc.Verify(m => m(It.IsAny<IProcessLogger>()), Times.Once);
+            mockRequester.Verify(a => a.SendMessageAsync(It.IsAny<string>()), Times.Never);
         }
 
         [Fact]
         public void InteractionWrapper_NoException_InnerFuncPassedProcessLogger()
         {
-            Mock<IMember> mockRequester = new();
+            Mock<IMember> mockAuthor = new();
 
             Mock<Func<IProcessLogger, Task<InteractionResult>>> mockFunc = new();
-            mockFunc.Setup(f => f.Invoke(It.IsAny<IProcessLogger>())).ReturnsAsync(InteractionResult.FromMessage("message"));
 
-            TestInteractionErrorHandler ih = new();
-            AssertCompletedTask(() => ih.TryProcessReportingErrorsAsync(123, mockRequester.Object, mockFunc.Object));
+            bool isProcessLoggerEqual = false;
 
-            mockFunc.Verify(m => m(It.IsNotNull<IProcessLogger>()), Times.Once);
-            mockFunc.Verify(m => m(It.Is<IProcessLogger>(pl => pl.GetType() == typeof(ProcessLogger))), Times.Once);
+            mockFunc.Setup(f => f.Invoke(It.IsAny<IProcessLogger>())).Callback<IProcessLogger>(pl =>
+            {
+                isProcessLoggerEqual = m_processLoggerMock.Object == pl;
+            }).ReturnsAsync(InteractionResult.FromMessage("message"));
+
+            TestInteractionErrorHandler ih = new(GetServiceProvider());
+            AssertCompletedTask(() => ih.TryProcessReportingErrorsAsync(123, mockAuthor.Object, mockFunc.Object));
+
+            Assert.True(isProcessLoggerEqual, "Process Logger from factory not passed");
+            mockAuthor.Verify(a => a.SendMessageAsync(It.IsAny<string>()), Times.Never);
+            m_processLoggerFactoryMock.Verify(lf => lf.Create(), Times.Once);
+            mockFunc.Verify(mf => mf.Invoke(It.IsAny<IProcessLogger>()), Times.Once);
         }
 
         [Fact]
@@ -55,7 +81,7 @@ namespace Test.Bot.Core
             var thrownException = new ApplicationException();
             mockFunc.Setup(m => m(It.IsAny<IProcessLogger>())).ThrowsAsync(thrownException);
 
-            TestInteractionErrorHandler ih = new();
+            TestInteractionErrorHandler ih = new(GetServiceProvider());
             AssertCompletedTask(() => ih.TryProcessReportingErrorsAsync(mockKey, mockAuthor.Object, mockFunc.Object));
 
             mockAuthor.Verify(m => m.SendMessageAsync(It.Is<string>(s => s.Contains(mockKey.ToString()))), Times.Once);
@@ -77,8 +103,28 @@ namespace Test.Bot.Core
             var thrownException = new ApplicationException();
             mockFunc.Setup(m => m(It.IsAny<IProcessLogger>())).ThrowsAsync(thrownException);
 
-            TestInteractionErrorHandler ih = new();
+            TestInteractionErrorHandler ih = new(GetServiceProvider());
             AssertCompletedTask(() => ih.TryProcessReportingErrorsAsync(123, mockAuthor.Object, mockFunc.Object));
+        }
+
+
+        [Fact(Skip="Not yet implemented")]
+        public void InteractionWrapper_ProcessTakesTooLong_StartsLogging()
+        {
+            Mock<IMember> mockAuthor = new();
+
+            Mock<Func<IProcessLogger, Task<InteractionResult>>> mockFunc = new();
+
+            var tcs = new TaskCompletionSource<InteractionResult>();
+
+            mockFunc.Setup(f => f.Invoke(It.IsAny<IProcessLogger>())).Returns(tcs.Task);
+
+            TestInteractionErrorHandler ih = new(GetServiceProvider());
+            AssertCompletedTask(() => ih.TryProcessReportingErrorsAsync(123, mockAuthor.Object, mockFunc.Object));
+
+            // TODO: TCS should take a while (may not be able to use AssertCompletedTask), and verify that PL had a "LogVerboseMessages" method called (or something)
+
+            mockAuthor.Verify(a => a.SendMessageAsync(It.IsAny<string>()), Times.Never);
         }
     }
 }

--- a/Test.Bot.Core/TestCurrentGame.cs
+++ b/Test.Bot.Core/TestCurrentGame.cs
@@ -302,5 +302,10 @@ namespace Test.Bot.Core
             Assert.Null(result);
         }
 
+
+        [Fact(Skip = "Not yet implemented")]
+        public void CurrenGame_OutputsVerboseLogging()
+        {
+        }
     }
 }

--- a/Test.Bot.Core/TestCurrentGame.cs
+++ b/Test.Bot.Core/TestCurrentGame.cs
@@ -294,18 +294,20 @@ namespace Test.Bot.Core
             TownSquareMock.SetupGet(c => c.Users).Returns(Enumerable.Empty<IMember>().ToList());
 
             BotGameplay gs = new(GetServiceProvider());
-            var t = gs.CurrentGameAsync(MockTownKey, InteractionAuthorMock.Object, ProcessLoggerMock.Object);
-            t.Wait(50);
-            Assert.True(t.IsCompleted);
+            var t = AssertCompletedTask(() => gs.CurrentGameAsync(MockTownKey, InteractionAuthorMock.Object, ProcessLoggerMock.Object));
 
-            IGame? result = t.Result;
-            Assert.Null(result);
+            Assert.Null(t);
         }
 
 
-        [Fact(Skip = "Not yet implemented")]
+        [Fact]
         public void CurrenGame_OutputsVerboseLogging()
         {
+            BotGameplay gs = new(GetServiceProvider());
+
+            AssertCompletedTask(() => gs.CurrentGameAsync(MockTownKey, InteractionAuthorMock.Object, ProcessLoggerMock.Object));
+
+            ProcessLoggerMock.Verify(pl => pl.LogVerbose(It.Is<string>(s => s.Contains("game", StringComparison.InvariantCultureIgnoreCase))), Times.AtLeastOnce);
         }
     }
 }

--- a/Test.Bot.Core/TestDayPhase.cs
+++ b/Test.Bot.Core/TestDayPhase.cs
@@ -1,4 +1,7 @@
-﻿using Xunit;
+﻿using Moq;
+using System;
+using Test.Bot.Core.Interaction;
+using Xunit;
 
 namespace Test.Bot.Core
 {
@@ -8,23 +11,38 @@ namespace Test.Bot.Core
 		public void TestDay_Completes()
 		{
 			var gs = CreateGameplayInteractionHandler();
-			var t = gs.CommandDayAsync(InteractionContextMock.Object);
-			t.Wait(50);
-			Assert.True(t.IsCompleted);
+
+			AssertCompletedTask(() => gs.CommandDayAsync(InteractionContextMock.Object));
 		}
 
 		[Fact]
 		public void TestVote_Completes()
 		{
 			var gs = CreateGameplayInteractionHandler();
-			var t = gs.CommandVoteAsync(InteractionContextMock.Object);
-			t.Wait(50);
-			Assert.True(t.IsCompleted);
+
+			AssertCompletedTask(() => gs.CommandVoteAsync(InteractionContextMock.Object));
 		}
 
-		[Fact(Skip="Not yet implemented")]
+		[Fact]
 		public void Day_OutputsVerboseLogging()
 		{
+			var gs = CreateGameplayInteractionHandler();
+
+
+			AssertCompletedTask(() => gs.CommandDayAsync(InteractionContextMock.Object));
+
+            ProcessLoggerMock.Verify(pl => pl.LogVerbose(It.Is<string>(s => s.Contains("day", StringComparison.InvariantCultureIgnoreCase))), Times.AtLeastOnce);
+		}
+
+
+		[Fact]
+		public void Vote_OutputsVerboseLogging()
+		{
+			var gs = CreateGameplayInteractionHandler();
+
+			AssertCompletedTask(() => gs.CommandVoteAsync(InteractionContextMock.Object));
+
+			ProcessLoggerMock.Verify(pl => pl.LogVerbose(It.Is<string>(s => s.Contains("vote", StringComparison.InvariantCultureIgnoreCase))), Times.AtLeastOnce);
 		}
 	}
 }

--- a/Test.Bot.Core/TestDayPhase.cs
+++ b/Test.Bot.Core/TestDayPhase.cs
@@ -21,5 +21,10 @@ namespace Test.Bot.Core
 			t.Wait(50);
 			Assert.True(t.IsCompleted);
 		}
+
+		[Fact(Skip="Not yet implemented")]
+		public void Day_OutputsVerboseLogging()
+		{
+		}
 	}
 }

--- a/Test.Bot.Core/TestGameplayMisc.cs
+++ b/Test.Bot.Core/TestGameplayMisc.cs
@@ -4,6 +4,7 @@ using Bot.Core.Interaction;
 using Moq;
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -13,6 +14,9 @@ namespace Test.Bot.Core
     {
         public TestGameplayMisc()
         {
+            var taskMock = RegisterMock(new Mock<ITask>(MockBehavior.Strict));
+            taskMock.Setup(t => t.Delay(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>())).Returns(new TaskCompletionSource().Task);
+
             RegisterService<ITownInteractionErrorHandler>(new TownInteractionErrorHandler(GetServiceProvider()));
         }
 

--- a/Test.Bot.Core/TestGameplayMisc.cs
+++ b/Test.Bot.Core/TestGameplayMisc.cs
@@ -13,7 +13,7 @@ namespace Test.Bot.Core
     {
         public TestGameplayMisc()
         {
-            RegisterService<ITownInteractionErrorHandler>(new TownInteractionErrorHandler());
+            RegisterService<ITownInteractionErrorHandler>(new TownInteractionErrorHandler(GetServiceProvider()));
         }
 
         [Fact]

--- a/Test.Bot.Core/TestNightPhase.cs
+++ b/Test.Bot.Core/TestNightPhase.cs
@@ -142,7 +142,7 @@ namespace Test.Bot.Core
             var gs = CreateGameplayInteractionHandler();
             AssertCompletedTask(() => gs.PhaseNightInternal(MockTownKey, InteractionAuthorMock.Object));
 
-            m_processLoggerMock.Verify(pl => pl.LogVerbose(It.IsAny<string>()), Times.AtLeastOnce);
+            m_processLoggerMock.Verify(pl => pl.LogVerbose(It.Is<string>(s => s.Contains("night", StringComparison.InvariantCultureIgnoreCase))), Times.AtLeastOnce);
         }
     }
 }

--- a/Test.Bot.Core/TestNightPhase.cs
+++ b/Test.Bot.Core/TestNightPhase.cs
@@ -135,5 +135,14 @@ namespace Test.Bot.Core
 
             InteractionAuthorMock.Verify(m => m.MoveToChannelAsync(It.Is<IChannel>(c => c == Cottage1Mock.Object)), Times.Never);
         }
+
+        [Fact]
+        public void Night_OutputsVerboseLogging()
+        {
+            var gs = CreateGameplayInteractionHandler();
+            AssertCompletedTask(() => gs.PhaseNightInternal(MockTownKey, InteractionAuthorMock.Object));
+
+            m_processLoggerMock.Verify(pl => pl.LogVerbose(It.IsAny<string>()), Times.AtLeastOnce);
+        }
     }
 }

--- a/Test.Bot.Core/TestNightPhase.cs
+++ b/Test.Bot.Core/TestNightPhase.cs
@@ -142,7 +142,7 @@ namespace Test.Bot.Core
             var gs = CreateGameplayInteractionHandler();
             AssertCompletedTask(() => gs.PhaseNightInternal(MockTownKey, InteractionAuthorMock.Object));
 
-            m_processLoggerMock.Verify(pl => pl.LogVerbose(It.Is<string>(s => s.Contains("night", StringComparison.InvariantCultureIgnoreCase))), Times.AtLeastOnce);
+            ProcessLoggerMock.Verify(pl => pl.LogVerbose(It.Is<string>(s => s.Contains("night", StringComparison.InvariantCultureIgnoreCase))), Times.AtLeastOnce);
         }
     }
 }

--- a/Test.Bot.Core/TestNightPhase.cs
+++ b/Test.Bot.Core/TestNightPhase.cs
@@ -11,7 +11,7 @@ namespace Test.Bot.Core
     {
         public TestNightPhase()
         {
-            RegisterService<ITownInteractionErrorHandler>(new TownInteractionErrorHandler());
+            RegisterService<ITownInteractionErrorHandler>(new TownInteractionErrorHandler(GetServiceProvider()));
         }
 
         [Theory]

--- a/Test.Bot.Core/TestProcessLogger.cs
+++ b/Test.Bot.Core/TestProcessLogger.cs
@@ -1,0 +1,130 @@
+﻿using Bot.Core;
+using Moq;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Test.Bot.Base;
+using Xunit;
+
+namespace Test.Bot.Core
+{
+    public class TestProcessLogger : TestBase
+    {
+        private readonly Mock<ILogger> m_mockLogger = new(MockBehavior.Strict);
+
+        public TestProcessLogger()
+        {
+            m_mockLogger.Setup(l => l.Debug(It.IsAny<string>(), It.IsAny<string>()));
+        }
+
+        [Fact]
+        public void LogWarning_GoesToSerilog()
+        {
+            var pl = new ProcessLogger(m_mockLogger.Object);
+
+            string message = "this is a message";
+            pl.LogMessage(message);
+
+            m_mockLogger.Verify(l => l.Debug(It.IsAny<string>(), It.Is<string>(m => m == message)), Times.Once);
+            m_mockLogger.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void LogVerbose_NoSerilogCalls()
+        {
+            var pl = new ProcessLogger(m_mockLogger.Object);
+
+            string message = "this is a message";
+            pl.LogVerbose(message);
+
+            m_mockLogger.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void EnableVerbose_LogVerbose_SerilogCall()
+        {
+            var pl = new ProcessLogger(m_mockLogger.Object);
+
+            pl.EnableVerboseLogging();
+
+            string message = "this is a message";
+            pl.LogVerbose(message);
+
+            m_mockLogger.Verify(l => l.Debug(It.IsAny<string>(), It.Is<string>(m => m == message)), Times.Once);
+            m_mockLogger.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void LogVerbose_EnableVerbose_SerilogCall()
+        {
+            var pl = new ProcessLogger(m_mockLogger.Object);
+
+            string message = "this is a message";
+            pl.LogVerbose(message);
+
+            pl.EnableVerboseLogging();
+
+            m_mockLogger.Verify(l => l.Debug(It.IsAny<string>(), It.Is<string>(m => m == message)), Times.Once);
+            m_mockLogger.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void LogVerboseMultipleTimes_EnableVerbose_SerilogCalls()
+        {
+            var pl = new ProcessLogger(m_mockLogger.Object);
+
+            string message1 = "this is message1";
+            string message2 = "this is message2";
+            pl.LogVerbose(message1);
+            pl.LogVerbose(message2);
+
+            pl.EnableVerboseLogging();
+
+            m_mockLogger.Verify(l => l.Debug(It.IsAny<string>(), It.Is<string>(m => m == message1)), Times.Once);
+            m_mockLogger.Verify(l => l.Debug(It.IsAny<string>(), It.Is<string>(m => m == message2)), Times.Once);
+            m_mockLogger.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void LogVerbose_EnableVerboseMultipleTimes_OneMessage()
+        {
+            var pl = new ProcessLogger(m_mockLogger.Object);
+
+            string message = "this is a message";
+            pl.LogVerbose(message);
+
+            pl.EnableVerboseLogging();
+            pl.EnableVerboseLogging();
+
+            m_mockLogger.Verify(l => l.Debug(It.IsAny<string>(), It.Is<string>(m => m == message)), Times.Once);
+            m_mockLogger.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void Log_Enable_Alternate_OneMessageEach()
+        {
+            var pl = new ProcessLogger(m_mockLogger.Object);
+
+            string message1 = "this is a message1";
+            string message2 = "this is a message2";
+            string message3 = "this is a message3";
+
+            pl.LogVerbose(message1);
+
+            pl.EnableVerboseLogging();
+
+            m_mockLogger.Verify(l => l.Debug(It.IsAny<string>(), It.Is<string>(m => m == message1)), Times.Once);
+            pl.LogVerbose(message2);
+            m_mockLogger.Verify(l => l.Debug(It.IsAny<string>(), It.Is<string>(m => m == message2)), Times.Once);
+
+            pl.EnableVerboseLogging();
+            pl.LogVerbose(message3);
+            m_mockLogger.Verify(l => l.Debug(It.IsAny<string>(), It.Is<string>(m => m == message3)), Times.Once);
+
+            m_mockLogger.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/Test.Bot.Core/TestServices.cs
+++ b/Test.Bot.Core/TestServices.cs
@@ -32,6 +32,7 @@ namespace Test.Bot.Core
         [InlineData(typeof(IGuildInteractionErrorHandler), typeof(GuildInteractionErrorHandler))]
         [InlineData(typeof(ITownInteractionErrorHandler), typeof(TownInteractionErrorHandler))]
         [InlineData(typeof(ICallbackSchedulerFactory), typeof(CallbackSchedulerFactory))]
+        [InlineData(typeof(IProcessLoggerFactory), typeof(ProcessLoggerFactory))]
         [InlineData(typeof(IComponentService), typeof(ComponentService))]
         [InlineData(typeof(IShuffleService), typeof(ShuffleService))]
         [InlineData(typeof(IFinalShutdownService), typeof(ShutdownService))]

--- a/Test.Bot.Core/TestVoteTimer.cs
+++ b/Test.Bot.Core/TestVoteTimer.cs
@@ -128,15 +128,7 @@ namespace Test.Bot.Core
         {
             var bc = new BotGameplay(GetServiceProvider());
 
-            var t = bc.PerformVoteAsync(MockTownKey);
-            t.Wait(50);
-            Assert.True(t.IsCompleted);
-        }
-
-
-        [Fact(Skip = "Not yet implemented")]
-        public void PerformVote_OutputsVerboseLogging()
-        {
+            AssertCompletedTask(() => bc.PerformVoteAsync(MockTownKey));
         }
 
         private void RunVoteTimerVerifyCompleted()

--- a/Test.Bot.Core/TestVoteTimer.cs
+++ b/Test.Bot.Core/TestVoteTimer.cs
@@ -133,6 +133,12 @@ namespace Test.Bot.Core
             Assert.True(t.IsCompleted);
         }
 
+
+        [Fact(Skip = "Not yet implemented")]
+        public void PerformVote_OutputsVerboseLogging()
+        {
+        }
+
         private void RunVoteTimerVerifyCompleted()
         {
             RunVoteTimerVerifyCompleted("");


### PR DESCRIPTION
This should help us catch cases where the bot just hangs for some guilds - notably Steini225 is frequently hitting issues where the bot just hangs up on their server while it works everywhere else.

In order to do this, we'll need a report of the approximate time the bot hangs up, then we should be able to check the logs around that time and look for "verbose". This should tell us at least what the bot is attempting to run next and is waiting on.