### PR TITLE
Change villager role color to orange for colorblind users

### DIFF
--- a/Bot.Core/BotSetup.cs
+++ b/Bot.Core/BotSetup.cs
@@ -399,7 +399,7 @@ namespace Bot.Core
             townDesc.FallbackToDefaults();
 
             // First create the roles for this town
-            newTown.StorytellerRole = await RoleHelper.GetOrCreateRole(guild, townDesc.StorytellerRoleName, Color.Magenta);
+            newTown.StorytellerRole = await RoleHelper.GetOrCreateRole(guild, townDesc.StorytellerRoleName, Color.Orange);
             if (newTown.StorytellerRole == null)
                 throw new CreateTownException($"Could not find or create Storyteller role '{townDesc.StorytellerRoleName}'");
 


### PR DESCRIPTION
When using Discord in dark mode and user is colorblind, it's quite hard to see villager names. This code review changes villager role color to a more accessible one.